### PR TITLE
Srcid metrics

### DIFF
--- a/_DENA/scripts/generate_geographic_metrics.py
+++ b/_DENA/scripts/generate_geographic_metrics.py
@@ -13,8 +13,11 @@ import warnings
 
 __all__ = [
     'clip_events_to_time_period',
+    'clip_srcid_to_time_period',
     'tracks2events',
+    'NFI_list',
     'get_all_stats',
+    'get_all_srcid_stats',
     'calculate_spatial_stats',
     'plot_events',
     'circular_sliding_avg',
@@ -58,6 +61,32 @@ def clip_events_to_time_period(df, start_col, end_col, start_date, end_date, mon
     df[start_col] = np.maximum(df[start_col].values, start_date)
     df[end_col] = np.minimum(df[end_col].values, end_date)
     return df
+
+
+def clip_srcid_to_time_period(src_data, start_date, end_date, months=list(range(1,13))):
+    """A wrapper function around `clip_events_to_time_period` to clip SRCID data.
+    """
+
+    # we'll filter an uninformative performance warning
+    warnings.filterwarnings("ignore", 
+                            message=".*Adding/subtracting object-dtype array to DatetimeArray not vectorized.*")
+
+    # the clipping function expects start and end datetimes, so we add two columns...
+    src_data["start_time"] = pd.to_datetime(src_data.index.to_series())
+    src_data["end_time"]   = pd.to_datetime(src_data["start_time"] + src_data["len"])
+    
+    src_clipped = clip_events_to_time_period(src_data,
+                                             start_col = "start_time",
+                                             end_col = "end_time",
+                                             start_date=np.datetime64(start_date),
+                                             end_date=np.datetime64(end_date),
+                                             months=months)
+
+    # just in case, we update the SRCID datatime information to match
+    src_clipped.index = src_clipped["start_time"]
+    src_clipped.len = src_clipped["end_time"] - src_clipped["start_time"]
+    
+    return src_clipped
 
 
 def tracks2events(tracks, start_date, end_date, min_dur=10, min_gap_dur=30):
@@ -271,12 +300,11 @@ def _agg_conf_intervals(series: pd.Series, agg_funcs: list):
     out = {}
     for f in agg_funcs:
         try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("error")
-                result = stats.bootstrap((series.values,), lambda x: f(pd.Series(x)),
-                                        confidence_level=0.95, n_resamples=1000, method="BCa")
+            result = stats.bootstrap((series.values,), lambda x: f(pd.Series(x)),
+                                    confidence_level=0.95, n_resamples=1000, method="percentile")
             out[f.__name__] = result.confidence_interval
-        except:
+        except Exception as e:
+            print(f"Error with function {f.__name__}: {e}")
             out[f.__name__] = (pd.NA, pd.NA)
     return pd.Series(out)
 
@@ -290,6 +318,62 @@ class Quantile:
     
     def __call__(self, series: pd.Series):
         return series.quantile(self.q)
+
+
+def NFI_list(srcid, source = "all", unit="hours"): 
+    """
+    Returns a DataFrame of all Noise Free Intervals for selected source type(s).
+
+    Parameters
+    ----------
+    srcid: pandas dataframe representing NPS NSNSD srcid file, formatted by soundDB library.
+    source: str or list of floats, optional.  Which subset of srcid codes to summarize - choose either "all", "air", or specify a list of srcID codes as float.  Defaults to "all" if unspecified.
+    unit: str, a value that indicates the units desired for the output value.  Defaults to "hours".
+
+    Returns
+    -------
+    pandas Series of floating-point times
+    """
+
+    # 'look-up' dictionary to translate time unit from string to integer (in seconds)
+    unitDict = {"seconds":1, "minutes":60, "hours":3600, "days":86400}
+
+    # because NFI depends on event timing, 
+    # it is critical to first sort chronologically
+    srcid.sort_index(inplace=True)
+
+    # two of the source categories are built-in as strings ("all", "air")
+    if(type(source) == str):
+        if(source.lower() == "all"):  
+
+            # difference the starting datetime indices to create a list of timedeltas
+            NFIlst = srcid.index.to_series().diff()
+
+        elif(source.lower() == "air"):
+
+            # aviation sources have source ID codes starting with 1: (1., 1.1, 1.2, 1.3, etc.)
+            srcid = srcid.loc[(srcid.srcID > 0) & (srcid.srcID < 2.), :]
+
+            # difference the starting datetime indices to create a list of timedeltas
+            NFIlst = srcid.index.to_series().diff()
+    else: 
+
+        # select only the source ID code of interest
+        srcid = srcid.loc[srcid.srcID.isin(source), :]
+
+        # difference the starting datetime indices to create a list of timedeltas
+        NFIlst = srcid.index.to_series().diff()
+
+    valid_NFIs = NFIlst[NFIlst > "00:00:00"]
+    NFI_df = pd.DataFrame([])
+    NFI_durations = pd.Series(np.array([m.total_seconds() for m in valid_NFIs])/unitDict[unit])
+    NFI_df["duration"] = NFI_durations
+    NFI_df["start_time"] = valid_NFIs.index
+    NFI_df["end_time"] = NFI_df["start_time"] + valid_NFIs.values
+    NFI_df.index = valid_NFIs.index
+    NFI_df = NFI_df.dropna()
+    
+    return NFI_df
 
 
 def get_all_stats(event_df, NFI_df, start_date, end_date, months=list(range(1,13)), quantiles=.5):
@@ -372,6 +456,90 @@ def get_all_stats(event_df, NFI_df, start_date, end_date, months=list(range(1,13
         #     conf_intervals[col] = conf_intervals[col].apply(lambda x: tuple(pd.to_timedelta(x, unit="s")))
     
     return pd.DataFrame(statistics), pd.DataFrame(conf_intervals), values    
+
+
+def get_all_srcid_stats(src_data, start_date, end_date, months=list(range(1,13)), quantiles=.5, src_list=[1.2,1.3]):
+    """Calculates all event statistics, given a set of events and corresponding noise free intervals (NFIs).
+    
+    Parameters
+    ----------
+    src_data: pd.DataFrame
+        A DataFrame containing canonical source identification data as returned by the Srcid().data attribute. 
+    start_date : string
+        The start date to begin calculating duration stats, formatted as 'yyyy-mm-dd'. Refers to midnight of this date.
+    end_date : string
+        The end date to stop calculating duration stats, formatted as 'yyyy-mm-dd'. Refers to midnight of this date, so no events occuring during this day will be captured.
+    months : int or list of ints (between 1 and 12)
+        Default is the full year, an optional input to specify the months of interest as a list of integers, 1-12. 
+        This is helpful for highly seasonal flight patterns, such as Denali's summer vs winter splits.
+    quantiles : float or list of floats (between 0 and 1)
+        Default is .5 (the median), specifies which quantiles to output. E.g., [.1, .5., .9] will output 10th, 50th, and 90th quantiles
+    src_list : list of floats
+        Default is [1.2,1.3], which includes propeller aircraft (1.2) and helicopters (1.3). Any source identification code may be used.
+        E.g., for vessels [3.0], for jets [1.1], etc.
+    
+    Returns
+    -------
+    Tuple of (statistics, confidence_intervals, data)
+        statistics: pd.DataFrame
+            DataFrame containing computed statistics.
+            Columns represent the metrics that statistics are computed for: event_duration, NFI_duration, daily_time_audible, daily_event_count, hourly_time_audible, hourly_event_count
+            Rows represent the statistic: mean, quantiles, min, max, std, median_abs_deviation 
+        confidence_intervals: pd.DataFrame
+            DataFrame containing 95% BCa confidence intervals for the mean and quantiles, computed using bootstrapping.
+            Columns are metric names, rows are statistic names.
+            Entries in the DataFrame are tuples representing the confidence intervals. Note that tuples may contain nan if the statistic
+            distribution was degenerate (always the same value when performing bootstrapping).
+        data: dict
+            A dictionary where keys are metric names, and values are pd.Series representing the data.
+    """
+
+    start_date = np.datetime64(start_date)  # Convert to datetime64
+    end_date = np.datetime64(end_date)      # Convert to datetime64
+
+    # Input validation. Both 'quantiles' and 'months' paramters must be converted to lists
+    quantiles = [quantiles] if type(quantiles)!=type([]) else quantiles
+    months = [months] if type(months)!=type([]) else months
+
+    # Make sure months are between 1 and 12
+    for month in months:
+        if (month < 1) | (month > 12):
+            print("Warning: Invalid months. Must be a list of integers from 1-12. Ignoring months parameter...")
+            months=list(range(1,13))
+
+    # notably, this function adds two columns "start_time" and "end_time"
+    # which are necessary to use the functions `NFI_list` and `_time_binned_df`
+    src_clip =  clip_srcid_to_time_period(src_data, 
+                                           start_date=start_date, 
+                                           end_date=end_date, 
+                                           months=months)
+
+    src_clip["duration"] = src_clip["len"].apply(lambda t: float(t.total_seconds()))
+    NFI_df = NFI_list(src_clip, source = src_list, unit="seconds")
+
+    # prepare the values we want statistics for
+    values = {
+        "event_duration": src_clip["duration"],
+        "NFI_duration": NFI_df["duration"]
+    }
+    # include time audible and event count, binned by hour and by day
+    for freq in ['d', 'h']:
+        binned_df = _time_binned_df(src_clip, start_date, end_date, months, freq)
+        for col in binned_df.columns:
+            values[col] = binned_df[col]
+    
+    # prepare the statistics we want
+    agg_stats = ["mean"] + [Quantile(q) for q in quantiles] + ["min", "max", "std", stats.median_abs_deviation]
+    conf_int_stats = [np.mean] + [Quantile(q) for q in quantiles]
+
+    # compute statistics
+    statistics = {}
+    conf_intervals = {}
+    for col, series in values.items():
+        statistics[col] = series.agg(agg_stats)
+        conf_intervals[col] = _agg_conf_intervals(series, conf_int_stats)
+    
+    return pd.DataFrame(statistics), pd.DataFrame(conf_intervals), values  
 
 
 def calculate_spatial_stats(tracks, active):
@@ -516,6 +684,7 @@ def circular_sliding_avg(vector, window_len):
     
     return smoothed
 
+
 def find_circular_peaks(column, distance_delta, peak_distance):
     '''
     A specific adaptation of SciPy.Signal's 'find_peaks' algorithm for use on an active space polygon.
@@ -557,6 +726,7 @@ def find_circular_peaks(column, distance_delta, peak_distance):
     # get rid of peaks in the prepended AND appended parts of the wrapped vector.
     sorted_peak_indices = sorted_peaks[(sorted_peaks >= samples_between_peaks) & (sorted_peaks < len(entries_vector)+samples_between_peaks)] - samples_between_peaks
     return sorted_peak_indices
+
 
 def endpoints_around_active(active, tracks, distance_delta, peak_distance, endpoint_type):
     '''
@@ -621,6 +791,7 @@ def endpoints_around_active(active, tracks, distance_delta, peak_distance, endpo
         return 0
                                             
     return active_gdf, peak_indices
+
 
 def identify_stereotypical_tracks(active, tracks, distance_delta=100, peak_distance=1000):
     '''

--- a/_DENA/scripts/generate_geographic_metrics.py
+++ b/_DENA/scripts/generate_geographic_metrics.py
@@ -507,20 +507,26 @@ def get_all_srcid_stats(src_data, start_date, end_date, months=list(range(1,13))
             print("Warning: Invalid months. Must be a list of integers from 1-12. Ignoring months parameter...")
             months=list(range(1,13))
 
+    src_filtered = src_data.loc[src_data.srcID.isin(src_list), :]
+
     # notably, this function adds two columns "start_time" and "end_time"
     # which are necessary to use the functions `NFI_list` and `_time_binned_df`
-    src_clip =  clip_srcid_to_time_period(src_data, 
+    src_clip =  clip_srcid_to_time_period(src_filtered, 
                                            start_date=start_date, 
                                            end_date=end_date, 
                                            months=months)
 
     src_clip["duration"] = src_clip["len"].apply(lambda t: float(t.total_seconds()))
-    NFI_df = NFI_list(src_clip, source = src_list, unit="seconds")
+    NFI_df = NFI_list(src_clip, source = "all", unit="seconds")
 
     # prepare the values we want statistics for
     values = {
         "event_duration": src_clip["duration"],
-        "NFI_duration": NFI_df["duration"]
+        "NFI_duration": NFI_df["duration"],
+        "SEL_A" : src_clip["SEL"].astype('float'),
+        "SEL_T" : src_clip["SELt"].astype('float'),
+        "LAmax" : src_clip["MaxSPL"].astype('float'),
+        "LTmax" : src_clip["MaxSPLt"].astype('float')
     }
     # include time audible and event count, binned by hour and by day
     for freq in ['d', 'h']:

--- a/_DENA/scripts/generate_geographic_metrics.py
+++ b/_DENA/scripts/generate_geographic_metrics.py
@@ -82,7 +82,7 @@ def clip_srcid_to_time_period(src_data, start_date, end_date, months=list(range(
                                              end_date=np.datetime64(end_date),
                                              months=months)
 
-    # just in case, we update the SRCID datatime information to match
+    # just in case, we update the SRCID datetime information to match
     src_clipped.index = src_clipped["start_time"]
     src_clipped.len = src_clipped["end_time"] - src_clipped["start_time"]
     

--- a/nps_active_space/utils/models.py
+++ b/nps_active_space/utils/models.py
@@ -34,6 +34,7 @@ __all__ = [
     'FAAReleasable',
     'Tracks',
     'Annotations',
+    'Srcid'
 ]
 
 
@@ -1571,3 +1572,226 @@ class Annotations(gpd.GeoDataFrame):
                                     geometry='geometry', crs='epsg:4326')
 
         super().__init__(data=data, crs=data.crs)
+
+class Srcid():
+    """
+    A pandas DataFrame wrapper class to ensure consistent SRCID data.
+
+    The ``nvsplDate``, ``hr``, and ``secs`` columns are combined into a single DatetimeIndex for the DataFrame and dropped.
+    The ``len`` column (length of the noise event) is converted to a pandas Timedelta.
+
+    Example Resulting DataFrame
+    ---------------------------
+
+    <class 'pandas.core.frame.DataFrame'>
+    DatetimeIndex: 971 entries, 2015-05-12 05:40:03 to 2015-07-14 23:55:11
+    Data columns (total 10 columns):
+    len         971 non-null timedelta64[ns]
+    srcID       971 non-null float64
+    Hz_L        971 non-null float64
+    Hz_U        971 non-null int64
+    MaxSPL      971 non-null float64
+    SEL         971 non-null float64
+    MaxSPLt     971 non-null float64
+    SELt        971 non-null float64
+    userName    971 non-null object
+    tagDate     971 non-null datetime64[ns]
+    dtypes: datetime64[ns](1), float64(6), int64(1), object(1), timedelta64[ns](1)
+    memory usage: 83.4+ KB
+
+    Parameters
+    ----------
+    srcid_path: str
+        Path to a single SRCID file one wishes to load.
+
+    merge: bool, default True
+        
+    Notes
+    -----
+    [1] The SRCID format, short for "Source Identification File" was initially developed by the U.S. National Park Service
+          circa 2008 as the primary output of `SPLAT.exe` (Sound Pressure Level Annotation Tool).
+    """
+
+    def __init__(self, srcid_path, merge=True):
+
+        self.srcid_path = srcid_path
+        self.merge = merge
+        self.data = None
+
+        src_raw = self._read()
+        self.data = src_raw # if `merge = False` then we stop here...
+        
+        if(merge): # ...however, by default we'd like to work with events spanning hours (or even days) as if they were annotated in their entirety
+            src = self._merge_SRCID(self.data)
+            self.data = src
+
+    def _read(self):
+        """
+        Read data, format and tidy fields, handle various edge cases.
+        """
+
+        with open(self.srcid_path) as f:
+
+            # Determine version; older versions immediately start with header, newer has version comment
+            firstline = f.readline()
+            if not firstline.startswith(r"%%"):
+                f.seek(0)   # Rewind, as we just consumed the header row.
+                            # Otherwise, we consumed the comment row, which is fine
+
+            data = pd.read_csv(f,
+                                engine= "c",
+                                sep= "\t",
+                                # skiprows= 1,
+                                parse_dates= False)
+
+        # Combine nvsplDate, hr, secs columns into one DatetimeIndex
+        dates = pd.to_datetime(data.nvsplDate, infer_datetime_format= True)
+        hrs   = pd.to_timedelta(data.hr, unit= "h")
+        secs  = pd.to_timedelta(data.secs, unit= "s")
+
+        data.drop(["nvsplDate", "hr", "secs"], axis= 1, inplace= True)
+        data.index = dates + hrs + secs
+
+        # Turn len into timedelta
+        data.len = pd.to_timedelta(data.len, unit= "s")
+
+        if 'sID' in data.columns:
+            # Some bizzare old files have a different name for srcID (really only DENAUSLC2008 so far)
+            data.rename(columns= {'sID': 'srcID'}, inplace= True)
+
+        # Days with no noise events are entered with the `MaxSPLt` and `SELt` columns skipped,
+        # so they get filled with userName and tagDate, giving them a mixed type instead of float
+        # Resolve this by finding zero-noise rows and setting all their values to NaN (more appropriate than 0)
+        if 'MaxSPLt' in data.columns:
+            if data.MaxSPLt.dtype == np.object_:
+                # There are noise-free days in this dataset
+                converted = pd.to_numeric(data[['MaxSPLt', 'SELt']], errors= "coerce")
+                noisefree = converted.isnull().all(axis= 1)
+                data.loc[noisefree, ["userName", "tagDate"]] = data.loc[noisefree, ['MaxSPLt', 'SELt']].values
+                data[['MaxSPLt', 'SELt']] = converted
+
+                nanCols = data.columns.difference(("userName", "tagDate"))
+                data.loc[ noisefree, nanCols ] = np.nan
+
+        # Parse tagDate to datetime (though old versions don't have tagDate)
+        if 'tagDate' in data.columns:
+            data.tagDate = pd.to_datetime(data.tagDate, infer_datetime_format= True)
+
+        return data
+
+    def _join_srcID_rows(self, df):
+
+        '''
+        Join a sequence of SRCID-based spectrogram annotations into a single annotation.
+        '''
+
+        new_begin = df.head(1).index[0]
+        new_length = df['len'].sum()
+        new_srcID = df["srcID"].values[0]
+        new_L = df['Hz_L'].min()
+        new_U = df['Hz_U'].max()
+        new_MaxA = "{0:.01f}".format(df["MaxSPL"].max())
+
+        new_user = df.head(1)["userName"].values[0]
+        new_tagdate = df.tail(1)["tagDate"][0]
+
+        # because SEL values are already normalized you just logarithmically add them
+        # this gives the total energy dose
+        new_SELA = "{0:.01f}".format(10*np.log10(np.power(10, df["SEL"]/10).sum()))
+
+        # repeat for truncated values
+        # older SRCID files do not have these values, resulting in a KeyError, so we exept those cases
+        try:
+            new_MaxT = "{0:.01f}".format(df["MaxSPLt"].max())
+            new_SELT = "{0:.01f}".format(10*np.log10(np.power(10, df["SELt"]/10).sum()))
+
+            joined = pd.DataFrame([new_length, new_srcID, new_L, new_U, new_MaxA, new_SELA, new_MaxT, new_SELT, new_user, new_tagdate], 
+                        columns=[new_begin], index=df.columns[:-1]).T
+
+        except KeyError:
+            joined = pd.DataFrame([new_length, new_srcID, new_L, new_U, new_MaxA, new_SELA, new_user, new_tagdate], 
+                columns=[new_begin], index=df.columns[:-1]).T
+
+        return joined
+    
+    def _merge_SRCID(self, src):
+
+        '''
+        Find SRCID-based spectrogram annotations that break across hours, and join them to create a
+        final, merged SRCID for more accurate calculations.
+        '''
+
+        # these are only the events that end during the last second of the hour
+        end_at_hour = src.loc[((src.index + src["len"]).dt.minute==59)&
+                            ((src.index + src["len"]).dt.second==59)]
+
+        start_at_hour = src.loc[(src.index.minute==0)&(src.index.second==0)]
+
+        # these are only the events that start during the first second of the hour
+        starts_at_hour_break = src.index[(src.index.minute==0)&(src.index.second==0)].to_series()
+
+        # IMPORTANT: these are the starts where there is definitely an ending one second before
+        # conveniently the next two lines handle both (1) matching srcid values, 
+        # and (2) lots of back-to-back-to-back hour long annotations!
+        matches_end = start_at_hour.copy()
+        matches_end.index = (start_at_hour.index + start_at_hour["len"] + dt.timedelta(seconds=1))
+
+        # the .isin method is extremely helpful for working backwards to get the matched starts
+        matches_start = end_at_hour[(end_at_hour.index + end_at_hour["len"] + dt.timedelta(seconds=1)).isin(start_at_hour.index)].copy()
+
+        # these are the real break-point annotations
+        cons = pd.concat([matches_start, matches_end]).sort_index().dropna()
+        cons = cons.drop_duplicates(keep="first") # frankly, it doesn't matter
+
+        # assign groups to each set of consecutive annotations 
+        # it's a huge benefit to group by source type first!
+        group = 1
+        for srcID, source_group in cons.groupby("srcID"):
+
+            for ts, annotation in source_group.sort_index().iterrows():
+
+                ends = ts + annotation["len"]
+
+                if((ts.minute!=0)&(ts.second!=0)&
+                (ends.minute==59)&(ends.second==59)):
+
+                    group = group + 1
+                    cons.loc[ts, "group"] = group
+
+                elif((ts.minute==0)&(ts.second==0)&
+                (ends.minute!=59)&(ends.second!=59)):
+
+                    cons.loc[ts, "group"] = group
+                    group = group + 1
+
+                else:
+                    cons.loc[ts, "group"] = group
+
+            # at the end of the current source type, 
+            # "flush" the current group
+            group = group + 1
+
+        frames = []
+
+        # now we can actually perform the joining operations
+        for group_number, pieces in cons.groupby('group'):
+
+            if(len(pieces) < 2):
+                # this removes single values - they don't actually need to be merged
+                cons.drop(pieces.index, inplace=True)
+
+            else:
+                frames.append(self._join_srcID_rows(pieces))
+
+        # here are all the joined data
+        merged_breaks = pd.concat(frames)
+
+        # now that everything is neat and tidy, we can get the lines
+        # not representing true breaks
+        no_breaks = src.loc[~src.index.isin(cons.index)]
+
+        # final SRCID file with events across hour breaks merged
+        merged_src = pd.concat([merged_breaks, no_breaks])
+        merged_src = merged_src.sort_index()
+
+        return merged_src

--- a/nps_active_space/utils/models.py
+++ b/nps_active_space/utils/models.py
@@ -1645,7 +1645,7 @@ class Srcid():
                                 parse_dates= False)
 
         # Combine nvsplDate, hr, secs columns into one DatetimeIndex
-        dates = pd.to_datetime(data.nvsplDate, infer_datetime_format= True)
+        dates = pd.to_datetime(data.nvsplDate)
         hrs   = pd.to_timedelta(data.hr, unit= "h")
         secs  = pd.to_timedelta(data.secs, unit= "s")
 
@@ -1675,7 +1675,7 @@ class Srcid():
 
         # Parse tagDate to datetime (though old versions don't have tagDate)
         if 'tagDate' in data.columns:
-            data.tagDate = pd.to_datetime(data.tagDate, infer_datetime_format= True)
+            data.tagDate = pd.to_datetime(data.tagDate)
 
         return data
 
@@ -1693,7 +1693,7 @@ class Srcid():
         new_MaxA = "{0:.01f}".format(df["MaxSPL"].max())
 
         new_user = df.head(1)["userName"].values[0]
-        new_tagdate = df.tail(1)["tagDate"][0]
+        new_tagdate = df.tail(1)["tagDate"].values[0]
 
         # because SEL values are already normalized you just logarithmically add them
         # this gives the total energy dose


### PR DESCRIPTION
- Introduces a parsing class for NPS source identification (SRCID) files.
- Implements a mirrored data analysis workflow to outputs of `ground_truthing`: `clip_srcid_to_time_period` wraps/mirrors `clip_events_to_time_period`, `get_all_srcid_stats` mirrors `get_all_stats`.

In the future it may be worthwhile to also aggregate the energy-based metrics {SEL, Lmax} which are available in SRCID files. For now, this functionality exceeds the inferential scope of the geographic metrics estimated by `NPS-ActiveSpace`. 