### PR TITLE
Add GitHub Actions CI for automated testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdal-bin libgdal-dev
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+          # Match the GDAL Python binding to the installed system version
+          GDAL_VERSION=$(gdal-config --version)
+          pip install "GDAL==${GDAL_VERSION}"
+
+          pip install numpy scipy pandas geopandas shapely pyproj rasterio fiona
+          pip install matplotlib KDEpy timezonefinder tqdm
+          pip install sqlalchemy beautifulsoup4 requests geopy pyvista
+          pip install "iyore @ git+https://github.com/nationalparkservice/iyore.git"
+          pip install pytest
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Run tests
+        run: pytest tests/ -v


### PR DESCRIPTION
This adds a GitHub Actions workflow that runs the pytest suite on every push to `main` and on pull requests targeting `main`.

The workflow installs GDAL from apt and pins the Python GDAL binding to match the system version, then installs the rest of the geospatial stack (rasterio, fiona, geopandas, shapely, pyproj, scipy, etc.) along with the `iyore` dependency from git.

Tested locally by confirming `pytest tests/ -v` passes after a clean install of the same dependency set.

Closes #71