### PR TITLE
Fix hardcoded Windows paths for cross-platform compatibility

### DIFF
--- a/nps_active_space/scripts/fit_3d_active_space.py
+++ b/nps_active_space/scripts/fit_3d_active_space.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     # fit active space model using annotations
     model = load_layered_activespace(project_dir, unit, site, year)
     annots = load_annotations(project_dir, unit, site, year)
-    plot_savepath = Rf"{project_dir}/{unit}{site}/precision_recall_3d_f1_{unit}{site}{year}.png"
+    plot_savepath = os.path.join(project_dir, f"{unit}{site}", f"precision_recall_3d_f1_{unit}{site}{year}.png")
     result = model.fit(annots, plot_savepath=plot_savepath)
     
     # save to output csv

--- a/nps_active_space/scripts/generate_active_space_batch.py
+++ b/nps_active_space/scripts/generate_active_space_batch.py
@@ -266,7 +266,8 @@ if __name__ == "__main__":
             continue
 
         # assemble and run the command
-        cmd = Rf"python -u -W ignore '{ACTIVE_SPACE_DIR}\scripts\generate_active_space.py' {options}"
+        script_path = os.path.join(ACTIVE_SPACE_DIR, "scripts", "generate_active_space.py")
+        cmd = f"python -u -W ignore '{script_path}' {options}"
         result_series = run_deployment(designator, cmd)
         # if it ran with no errors, save the results
         if result_series is not None:

--- a/nps_active_space/utils/helpers.py
+++ b/nps_active_space/utils/helpers.py
@@ -64,9 +64,9 @@ def omni_to_gain(omni_source: str) -> float:
 
 
 def load_layered_activespace(project_dir, unit, site, year, gain=None, crs="epsg:4326"):
-    prefix = Rf"{project_dir}\{unit}{site}\Output_Data\ACTIVESPACES"
+    prefix = os.path.join(project_dir, f"{unit}{site}", "Output_Data", "ACTIVESPACES")
     layer_dirs = {}
-    output_dirs = glob.glob(Rf"{prefix}\{unit}{site}{year}_*m")
+    output_dirs = glob.glob(os.path.join(prefix, f"{unit}{site}{year}_*m"))
     for dir in output_dirs:
         altitude = int(os.path.basename(dir).split("_")[1].split("m")[0])
         layer_dirs[altitude] = dir
@@ -106,7 +106,7 @@ def load_activespace(project_dir, unit, site, year, gain, altitude_m=None, crs=N
 
     # pick middle altitude if no altitude provided
     if altitude_m is None:
-        altitude_dirs = glob.glob(Rf"{prefix}\{unit}{site}{year}_*m")
+        altitude_dirs = glob.glob(os.path.join(prefix, f"{unit}{site}{year}_*m"))
         altitudes = []
         for dir in altitude_dirs:
             altitudes.append(int(os.path.basename(dir).split("_")[1].split("m")[0]))
@@ -118,7 +118,7 @@ def load_activespace(project_dir, unit, site, year, gain, altitude_m=None, crs=N
     sign = "-" if gain < 0 else "+"
     gain_string = str(np.abs(int(10*gain))).zfill(3)
     usy = f"{unit}{site}{year}"
-    path = Rf"{prefix}\{usy}_{altitude_m}m\{usy}_O_{sign}{gain_string}.geojson"
+    path = os.path.join(prefix, f"{usy}_{altitude_m}m", f"{usy}_O_{sign}{gain_string}.geojson")
     active_space = gpd.read_file(path)
 
     if crs is not None:
@@ -553,14 +553,14 @@ def get_omni_sources(lower: float, upper: float) -> List[str]:
     assert upper % .5 == 0, "Invalid upper limit. Value must be divisible by 0.5."
     assert lower % .5 == 0, "Invalid lower limit. Value must be divisible by 0.5."
 
-    omni_source_dir = f"{ACTIVE_SPACE_DIR}\\data\\tuning"
+    omni_source_dir = os.path.join(ACTIVE_SPACE_DIR, "data", "tuning")
     omni_sources = []
 
     for i in range(int(lower*10), int(upper*10+5), 5):
         if i < 0:
-            omni_sources.append(f"{omni_source_dir}\\O_{i:04}.src")
+            omni_sources.append(os.path.join(omni_source_dir, f"O_{i:04}.src"))
         elif i >= 0:
-            omni_sources.append(f"{omni_source_dir}\\O_+{i:03}.src")
+            omni_sources.append(os.path.join(omni_source_dir, f"O_+{i:03}.src"))
 
     return omni_sources
 


### PR DESCRIPTION
## Summary

Several path constructions in the codebase use Windows-only backslash separators
(via `Rf"..."` raw f-strings or literal `\\` joins). These break on macOS and
Linux because the backslash is not treated as a path separator on those platforms.

This PR replaces all of them with `os.path.join()`, which uses the correct
separator for whatever OS the code is running on.

### What changed

- `helpers.py` - `load_layered_activespace()`, `load_activespace()`, and
  `get_omni_sources()` all had hardcoded backslash paths
- `generate_active_space_batch.py` - the subprocess command that calls
  `generate_active_space.py` used a backslash path
- `fit_3d_active_space.py` - the plot save path used a mixed `Rf"..."` string

The legacy_code directory also has Windows paths, but those files are clearly
historical and not part of the active package, so I left them as-is.

### Testing

All modified files pass `py_compile`. The changes are mechanical (same path
components, just joined with `os.path.join` instead of `\`), so behavior on
Windows is unchanged while macOS/Linux now works correctly.

Partially related to #51 (that issue covers the hardcoded Alaska Albers
projection, but improving cross-platform support is in the same spirit of
making the package usable outside its original environment).