### PR TITLE
Add GitHub issue templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in the details below
+        so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear summary of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we trigger this bug?
+      placeholder: |
+        1. Load a DEM raster with ...
+        2. Call `active_space.compute(...)` with ...
+        3. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please share your setup so we can try to reproduce the issue.
+      placeholder: |
+        - OS: e.g. Windows 11, macOS 14, Ubuntu 22.04
+        - Python version: e.g. 3.12
+        - GDAL version: e.g. 3.8.4
+        - NPS-ActiveSpace version or commit: e.g. v0.1.0 / abc1234
+        - Relevant park/site data (if applicable)
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Output / Logs
+      description: Paste any traceback or log output here.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a new feature or an improvement to existing functionality?
+        Please describe it below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to see added or changed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Why is this useful? Describe the problem it solves or the workflow it improves.
+      placeholder: |
+        e.g. When analyzing acoustic monitoring data for a coastal park, I need to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: |
+        If you have thoughts on how this could work, share them here. Code snippets,
+        sketches, or references to similar tools are all welcome.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you tried any workarounds or other approaches?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds structured issue templates so that new bug reports and feature requests follow a consistent format. This should help keep issues organized, especially as the project grows or takes external contributions.

- **Bug report** (`bug_report.yml`): asks for a description, reproduction steps, expected behavior, environment info (OS, Python version, GDAL version, park/site data), and error logs
- **Feature request** (`feature_request.yml`): asks for a description, use case, proposed solution, and alternatives considered
- **Config** (`config.yml`): keeps blank issues enabled for anything that doesn't fit a template

Both templates use the YAML form format (not the older markdown template format), which gives contributors structured input fields in the GitHub UI.

Closes #65

## Test plan

- [ ] After merging, visit the "New Issue" page for the repo and confirm both templates appear as options
- [ ] Verify blank issues can still be opened
- [ ] Try submitting a test issue with each template to confirm fields render correctly