### PR TITLE
Add missing LICENSE.md (CC0 1.0 Universal)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,25 @@
+# License
+
+As a work of the [United States government](https://www.usa.gov/), this project is in the public domain within the United States of America.
+
+Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of their rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute, and perform the work, even for commercial purposes, all without asking permission.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.
+
+## Contributions
+
+All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.


### PR DESCRIPTION
The README links to `LICENSE.md` on [line 343](https://github.com/dbetchkal/NPS-ActiveSpace/blob/main/README.md#L343) but the file does not exist in the repository. Clicking the "public domain" link from the License section gives a 404.

This adds a `LICENSE.md` with the standard CC0 1.0 Universal public domain dedication text, following the format commonly used by US government open source projects (e.g., 18F/GSA repos). The wording is consistent with what the README and CITATION.cff already state about the project being in the public domain.

The file includes:

- The CC0 1.0 human-readable summary with a link to the full legal code
- A contributions section noting that PRs are released under the same CC0 dedication (matching the existing README text)