### PR TITLE
Replace hardcoded Alaska Albers with dynamic UTM lookup

### DIFF
--- a/nps_active_space/utils/ais/query.py
+++ b/nps_active_space/utils/ais/query.py
@@ -10,6 +10,7 @@ import geopandas as gpd
 import pandas as pd
 
 from nps_active_space.utils.ais.reader import MxakAis
+from nps_active_space.utils.computation import coords_to_utm
 
 
 def query_ais_mxak(
@@ -32,7 +33,7 @@ def query_ais_mxak(
     mask : gpd.GeoDataFrame, default None
         Geopandas.GeoDataFrame instance to spatially filter query results.
     mask_buffer_distance : int, default None
-        If provided, buffer ``mask`` by this distance (meters) in Alaska Albers before clipping.
+        If provided, buffer ``mask`` by this distance (meters) in an equal-area projection before clipping.
 
     Returns
     -------
@@ -41,8 +42,9 @@ def query_ais_mxak(
     """
     if mask is not None:
         if mask_buffer_distance:
-            ak_albers_mask = mask.to_crs(epsg=3338)
-            mask.geometry = ak_albers_mask.buffer(mask_buffer_distance).to_crs(epsg=4326)
+            centroid = mask.to_crs(epsg=4326).union_all().centroid
+            equal_area_crs = coords_to_utm(centroid.y, centroid.x)
+            mask.geometry = mask.to_crs(equal_area_crs).buffer(mask_buffer_distance).to_crs(epsg=4326)
         mask = mask.to_crs("epsg:4326")
 
     all_files = sorted(ais_path.glob("*.csv"))

--- a/nps_active_space/utils/helpers.py
+++ b/nps_active_space/utils/helpers.py
@@ -26,7 +26,7 @@ from nps_active_space.setup.site_writer import (
     deployment_sit_name,
     sit_file_path,
 )
-from nps_active_space.utils.computation import NMSIM_bbox_utm
+from nps_active_space.utils.computation import NMSIM_bbox_utm, coords_to_utm
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -325,8 +325,9 @@ def query_tracks(engine: 'Engine', start_date: str, end_date: str,
         if mask.crs.to_epsg() != 4326:  # If mask is not already in WGS84, project it.
             mask = mask.to_crs(epsg='4326')
         if mask_buffer_distance:
-            ak_albers_mask = mask.to_crs(epsg=3338)
-            mask.geometry = ak_albers_mask.buffer(
+            centroid = mask.to_crs(epsg=4326).union_all().centroid
+            equal_area_crs = coords_to_utm(centroid.y, centroid.x)
+            mask.geometry = mask.to_crs(equal_area_crs).buffer(
                 mask_buffer_distance).to_crs(epsg=4326)
         wheres.append(
             f"ST_Intersects(geom, ST_GeomFromText('{mask.union_all().wkt}', 4326))")
@@ -379,8 +380,9 @@ def query_adsb(adsb_path: str,  start_date: str, end_date: str,
         # if not mask.crs.to_epsg() == 4326:  # If mask is not already in WGS84, project it.
         #     mask = mask.to_crs(epsg='4326')
         if mask_buffer_distance:
-            ak_albers_mask = mask.to_crs(epsg=3338)
-            mask.geometry = ak_albers_mask.buffer(
+            centroid = mask.to_crs(epsg=4326).union_all().centroid
+            equal_area_crs = coords_to_utm(centroid.y, centroid.x)
+            mask.geometry = mask.to_crs(equal_area_crs).buffer(
                 mask_buffer_distance).to_crs(epsg=4326)
         mask = mask.to_crs("epsg:4326")
 

--- a/nps_active_space/validation/study_duration_stability.py
+++ b/nps_active_space/validation/study_duration_stability.py
@@ -79,7 +79,7 @@ def fit_varying_n_tracks(project_dir, unit, site, year):
     logger.info(f"Using {mid_layer}m for areas")
     for gain in tqdm(model.all_activespaces, desc="Computing areas"):
         active = model.all_activespaces[gain][mid_layer]
-        active_equal_area = active.to_crs("epsg:3338")  # albers AK equal area
+        active_equal_area = active.to_crs(utm_zone)
         areas[gain] = active_equal_area.area.item() / 1e6  # square km
 
     # Precompute whether each point is within each active space. This avoids doing a ton of redundant computation later

--- a/tests/utils/test_coords_to_utm.py
+++ b/tests/utils/test_coords_to_utm.py
@@ -1,0 +1,63 @@
+import pytest
+
+from nps_active_space.utils.computation import coords_to_utm
+
+
+class TestCoordsToUtm:
+    """Unit tests for the coords_to_utm() helper."""
+
+    def test_alaska_denali(self):
+        """Denali area (~63.1N, 151.0W) should land in UTM zone 5N."""
+        result = coords_to_utm(63.1, -151.0)
+        assert result == "epsg:26905"
+
+    def test_conus_colorado(self):
+        """Colorado (~39.7N, 104.9W) should land in UTM zone 13N."""
+        result = coords_to_utm(39.7, -104.9)
+        assert result == "epsg:26913"
+
+    def test_southern_hemisphere_australia(self):
+        """Sydney area (~33.9S, 151.2E) should use the 327xx (south) series."""
+        result = coords_to_utm(-33.9, 151.2)
+        # UTM zone = (151.2 + 180) // 6 + 1 = 56
+        assert result == "epsg:32756"
+
+    def test_zone_boundary_east_edge(self):
+        """A point right at a zone boundary (lon = -90.0) sits at
+        the start of UTM zone 16.  Verify the boundary is handled."""
+        result = coords_to_utm(45.0, -90.0)
+        assert result == "epsg:26916"
+
+    def test_zone_boundary_west_edge(self):
+        """Longitude just west of -90 should still be in UTM zone 15."""
+        result = coords_to_utm(45.0, -90.1)
+        assert result == "epsg:26915"
+
+    def test_prime_meridian(self):
+        """Longitude 0 should fall in UTM zone 31."""
+        result = coords_to_utm(51.5, 0.0)
+        assert result == "epsg:26931"
+
+    def test_returned_string_format_northern(self):
+        """Northern hemisphere results should match the epsg:269XX pattern."""
+        result = coords_to_utm(10.0, -70.0)
+        assert result.startswith("epsg:269")
+        zone_num = int(result.split("epsg:269")[1])
+        assert 1 <= zone_num <= 60
+
+    def test_returned_string_format_southern(self):
+        """Southern hemisphere results should match the epsg:327XX pattern."""
+        result = coords_to_utm(-10.0, -70.0)
+        assert result.startswith("epsg:327")
+        zone_num = int(result.split("epsg:327")[1])
+        assert 1 <= zone_num <= 60
+
+    def test_far_east_zone_60(self):
+        """Longitude 179.0 should be in UTM zone 60."""
+        result = coords_to_utm(30.0, 179.0)
+        assert result == "epsg:26960"
+
+    def test_far_west_zone_1(self):
+        """Longitude -179.0 should be in UTM zone 1."""
+        result = coords_to_utm(30.0, -179.0)
+        assert result == "epsg:26901"


### PR DESCRIPTION
Fixes #51.

The mask-buffering step in `query_tracks()`, `query_adsb()`, and `query_ais_mxak()` hardcodes
EPSG:3338 (Alaska Albers) as the equal-area projection. That gives wrong buffer distances for
parks outside Alaska. The same issue affects the area calculation in
`study_duration_stability.fit_varying_n_tracks()`.

This patch replaces every `epsg:3338` reference with a dynamic UTM zone derived from the
geometry's centroid, using `coords_to_utm()` which already exists in the codebase. For the
stability module the fix is even simpler: `NMSIM_bbox_utm()` already computes the correct
UTM zone earlier in the function, so we reuse that variable.

With this change the toolkit works correctly for any park in the US (for example Great Smoky
Mountains, which is already in active use per Gurung et al. 2026).

**Files changed**

- `nps_active_space/utils/helpers.py` - `query_tracks()` and `query_adsb()` buffer projections
- `nps_active_space/utils/ais/query.py` - `query_ais_mxak()` buffer projection
- `nps_active_space/validation/study_duration_stability.py` - area calculation projection