### PR TITLE
Fix typos in comments, docstrings, and docs

### DIFF
--- a/legacy_code/analysis/FINAL - 2023 11 21 DEV NPS-ActiveSpace.analysis module.py
+++ b/legacy_code/analysis/FINAL - 2023 11 21 DEV NPS-ActiveSpace.analysis module.py
@@ -520,7 +520,7 @@ def contiguous_regions(condition):
     
     """
 
-    # Find the indicies of changes in "condition"
+    # Find the indices of changes in "condition"
     d = np.diff(condition)
     idx, = d.nonzero() 
 

--- a/legacy_code/flight_track_truthing.py
+++ b/legacy_code/flight_track_truthing.py
@@ -188,7 +188,7 @@ for _id, start, end in temporal_boundaries:
             tracks = tracks[tracks["id"] != _id]
 
         else:
-            print("\tUnknown error has occured, proceeding with other data...")
+            print("\tUnknown error has occurred, proceeding with other data...")
 
         continue  # skip the rest of this track
 

--- a/legacy_code/run_audible_transits_circlespace.py
+++ b/legacy_code/run_audible_transits_circlespace.py
@@ -236,7 +236,7 @@ class AudibleTransits:
 
     def update_track_parameters(self, tracks='self'):
         '''
-        Updates physical paramters of each track. 
+        Updates physical parameters of each track.
         Includes the following:
                                 - entry_time and exit_time: datetimes at the beginning and end of a track
                                 - entry_position and exit_position: Shapely Points at the beginning and end of a track
@@ -2383,7 +2383,7 @@ class AudibleTransitsADSB(AudibleTransits):
         print("Sinuosity>=1.1 takeoffs/landings: ", sinu)
         print("Slow speeds takeoffs/landings: ", slow)
 
-        # Add/update columns related to takeoff/landing paramters and booleans
+        # Add/update columns related to takeoff/landing parameters and booleans
         tracks['takeoff'] = takeoffs
         tracks['landing'] = landings
         tracks['needs_extrapolation'] = updated_needs_extrapolation

--- a/nps_active_space/scripts/README.md
+++ b/nps_active_space/scripts/README.md
@@ -23,7 +23,7 @@ This directory contains the scripts along with instruction for their use via a c
 These are the steps for the **primary use case**: synthesizing a 3D active space $\rightarrow$ using it to predict acoustic metrics geographically.
 
 1. Follow installation and data setup steps [here](https://github.com/dbetchkal/NPS-ActiveSpace/tree/v3_docs?tab=readme-ov-file#installation).
-2. Use `run_ground_truthing.py` to annotate audible track segments. This GUI-based tool establishes a spatio-temporal $\text{JOIN}$ of vechicle positions (cause) and acoustic records (effect).
+2. Use `run_ground_truthing.py` to annotate audible track segments. This GUI-based tool establishes a spatio-temporal $\text{JOIN}$ of vehicle positions (cause) and acoustic records (effect).
 3. Use `plot_altitudes.py` to scope the altitudes spanned by aircraft traffic traversing the study area.
 4. Use `generate_3d_active_space.py` to create a batch commands file based on the altitude range, generate active space layers, and fit the optimal gain. The fit results will be stored in `fits.csv` in the project directory.
 5. Use `run_audible_transits.py` to predict audible transits based on the active space.
@@ -89,7 +89,7 @@ check_study_duration_robustness.py
 
 ## Batch Generation
 
-If you want to generate many active spaces at the same time, you can leverate the batch script to do so. This is useful for running it overnight or while you do other work.
+If you want to generate many active spaces at the same time, you can leverage the batch script to do so. This is useful for running it overnight or while you do other work.
 
 ### Batch 3D Active Space
 

--- a/nps_active_space/scripts/run_audible_transits.py
+++ b/nps_active_space/scripts/run_audible_transits.py
@@ -2400,7 +2400,7 @@ class AudibleTransitsADSB(AudibleTransits):
         logger.debug(f"Sinuosity>=1.1 takeoffs/landings: {sinu}")
         logger.debug(f"Slow speeds takeoffs/landings: {slow}")
 
-        # Add/update columns related to takeoff/landing paramters and booleans
+        # Add/update columns related to takeoff/landing parameters and booleans
         tracks['takeoff'] = takeoffs
         tracks['landing'] = landings
         tracks['needs_extrapolation'] = updated_needs_extrapolation

--- a/nps_active_space/utils/computation.py
+++ b/nps_active_space/utils/computation.py
@@ -482,7 +482,7 @@ def contiguous_regions(condition):
 
     """
 
-    # Find the indicies of changes in "condition"
+    # Find the indices of changes in "condition"
     d = np.diff(condition)
     idx, = d.nonzero() 
 
@@ -535,7 +535,7 @@ def audibility_to_interval(aud, invert=False):
     if invert == True:
         aud = np.invert(aud) # invert detection mappings
     
-    # compute naiive intervals
+    # compute naive intervals
     noise_intervals = contiguous_regions(aud == True)
     noise_free_intervals_naiive = contiguous_regions(aud == False)
     
@@ -860,9 +860,9 @@ def atmospheric_absorption(frequency, atm_pressure, air_temp_celsius=25., percen
     atm_pressure: float
         The atmospheric pressure, in kPa
     air_temp_celsius: float
-        The air temperature, in degrees Celsius. Defautl 25
+        The air temperature, in degrees Celsius. Default 25
     percent_relative_humidity: float
-        The relative humidty. Should be between 0 and 100, inclusive. Default 75
+        The relative humidity. Should be between 0 and 100, inclusive. Default 75
 
     Returns
     -------

--- a/nps_active_space/utils/metrics.py
+++ b/nps_active_space/utils/metrics.py
@@ -428,7 +428,7 @@ def get_all_geo_stats(tracks, periods, months=list(range(1,13)), quantiles=.5):
         A dictionary where keys are metric names, and values are pd.Series representing the data.
     """
 
-    # Input validation. Both 'quantiles' and 'months' paramters must be converted to lists
+    # Input validation. Both 'quantiles' and 'months' parameters must be converted to lists
     quantiles = [quantiles] if type(quantiles)!=type([]) else quantiles
     months = [months] if type(months)!=type([]) else months
 
@@ -598,7 +598,7 @@ def get_all_srcid_stats(src_data, periods, months=list(range(1,13)), quantiles=.
         A dictionary where keys are metric names, and values are pd.Series representing the data.
     """
 
-    # Input validation. Both 'quantiles' and 'months' paramters must be converted to lists
+    # Input validation. Both 'quantiles' and 'months' parameters must be converted to lists
     quantiles = [quantiles] if type(quantiles)!=type([]) else quantiles
     months = [months] if type(months)!=type([]) else months
 


### PR DESCRIPTION
Fixes a handful of spelling mistakes scattered across comments, docstrings, and the scripts README. Only text in comments and documentation was touched - no variable names, function names, or other identifiers were changed.

Summary of corrections:

- `paramters` -> `parameters` in metrics.py (two occurrences) and run_audible_transits.py
- `indicies` -> `indices` in computation.py
- `naiive` -> `naive` in a comment in computation.py (the variable `noise_free_intervals_naiive` was intentionally left as-is)
- `Defautl` -> `Default` in a docstring in computation.py
- `humidty` -> `humidity` in a docstring in computation.py
- `vechicle` -> `vehicle` in scripts/README.md
- `leverate` -> `leverage` in scripts/README.md
- `occured` -> `occurred` in legacy_code/flight_track_truthing.py