### PR TITLE
Fix CI failures after GitHub Actions merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,9 @@ jobs:
           GDAL_VERSION=$(gdal-config --version)
           pip install "GDAL==${GDAL_VERSION}"
 
-          pip install numpy scipy pandas geopandas shapely pyproj rasterio fiona
+          pip install "numpy" "scipy" "pandas>=2.2,<3" geopandas shapely pyproj rasterio fiona
           pip install matplotlib KDEpy timezonefinder tqdm
-          pip install sqlalchemy beautifulsoup4 requests geopy pyvista
+          pip install sqlalchemy psycopg2-binary beautifulsoup4 requests geopy pyvista
           pip install "iyore @ git+https://github.com/nationalparkservice/iyore.git"
           pip install pytest
 

--- a/nps_active_space/utils/ais/timestamp_parsing.py
+++ b/nps_active_space/utils/ais/timestamp_parsing.py
@@ -33,14 +33,24 @@ def _parse_ak_local_with_dst_fallback(
         # AKST and AKDT rows (November AKST→AKDT, March AKDT→AKST).
         akst = time.loc[time.str.endswith("AKST")]
         akdt = time.loc[time.str.endswith("AKDT")]
-        parsed = pd.Series(index=time.index, dtype="datetime64[ns]")
-        parsed.loc[akst.index] = (
-            pd.to_datetime(akst, format=_MXAK_TIMESTAMP_PATTERNS[4]) + _AKST_UTC_OFFSET
-        )
-        parsed.loc[akdt.index] = (
-            pd.to_datetime(akdt, format=_MXAK_TIMESTAMP_PATTERNS[5]) + _AKDT_UTC_OFFSET
-        )
-        return parsed
+        parsed = pd.Series(pd.NaT, index=time.index)
+        result_dtype = None
+        if not akst.empty:
+            akst_parsed = (
+                pd.to_datetime(akst, format=_MXAK_TIMESTAMP_PATTERNS[4])
+                + _AKST_UTC_OFFSET
+            )
+            parsed.loc[akst.index] = akst_parsed
+            result_dtype = akst_parsed.dtype
+        if not akdt.empty:
+            akdt_parsed = (
+                pd.to_datetime(akdt, format=_MXAK_TIMESTAMP_PATTERNS[5])
+                + _AKDT_UTC_OFFSET
+            )
+            parsed.loc[akdt.index] = akdt_parsed
+            result_dtype = akdt_parsed.dtype
+        # .loc assignment widens to datetime64[ns]; restore pd.to_datetime resolution.
+        return parsed.astype(result_dtype)
 
 
 def parse_mxak_ais_timestamps(time: pd.Series) -> pd.Series:

--- a/nps_active_space/utils/computation.py
+++ b/nps_active_space/utils/computation.py
@@ -154,7 +154,8 @@ def interpolate_spline(points: 'Tracks', ds: int = 1, s: float = None) -> gpd.Ge
     try:
         tck, u = interpolate.splprep(x=coords, u=elapsed_seconds, k=k, s=s)
     except ValueError as exc:
-        if "invalid" in str(exc).lower():
+        msg = str(exc).lower()
+        if "invalid" in msg or "error on input data" in msg:
             raise ValueError(
                 "Spline interpolation failed for this track: duplicate or "
                 "non-increasing point_dt values. Each track point needs a "

--- a/tests/utils/ais/test_alignment.py
+++ b/tests/utils/ais/test_alignment.py
@@ -19,8 +19,15 @@ from nps_active_space.utils.models import Nvspl
 from nps_active_space.utils.time_utils import site_timezone_name, utc_naive_to_site_naive
 
 REPO = Path(__file__).resolve().parents[3]
-AIS_MAY24 = REPO / "example_data" / "AIS" / "MXAK-AIS-GLBA-20240524.csv"
-NVSPL_DIR = REPO / "example_data" / "NVSPL" / "GLBALSTL_2024"
+AIS_MAY24 = REPO / "example_data" / "MXAK-AIS-GLBA" / "MXAK-AIS-GLBA-20240524.csv"
+NVSPL_DIR = (
+    REPO
+    / "example_data"
+    / "nvspl_archive"
+    / "2024 GLBALSTL Lower South Tidal Inlet"
+    / "01 DATA"
+    / "NVSPL"
+)
 SHIP_VISITS = REPO / "example_data" / "GLBALSTL_ship_visits.csv"
 
 GLBALSTL_LAT, GLBALSTL_LON = 58.78, -136.32

--- a/tests/utils/ais/test_query.py
+++ b/tests/utils/ais/test_query.py
@@ -9,7 +9,7 @@ from nps_active_space.utils.ais.query import query_ais_mxak
 from nps_active_space.utils.ais.reader import MxakAis
 
 REPO = Path(__file__).resolve().parents[3]
-AIS_FIXTURE = REPO / "example_data" / "AIS" / "MXAK-AIS-GLBA-20250107.csv"
+AIS_FIXTURE = REPO / "example_data" / "MXAK-AIS-GLBA" / "MXAK-AIS-GLBA-20250107.csv"
 AIS_DIR = AIS_FIXTURE.parent
 
 METADATA_COLS = ["TIME", "MMSI", "lat", "lon", "ship_name", "shiptype", "altitude", "event_id"]

--- a/tests/utils/ais/test_reader.py
+++ b/tests/utils/ais/test_reader.py
@@ -8,7 +8,7 @@ from pandas.testing import assert_frame_equal
 from nps_active_space.utils.ais.reader import MxakAis
 
 REPO = Path(__file__).resolve().parents[3]
-AIS_FIXTURE = REPO / "example_data" / "AIS" / "MXAK-AIS-GLBA-20250107.csv"
+AIS_FIXTURE = REPO / "example_data" / "MXAK-AIS-GLBA" / "MXAK-AIS-GLBA-20250107.csv"
 ANNA_MMSI = 368018710
 
 METADATA_COLS = ["TIME", "MMSI", "lat", "lon", "ship_name", "shiptype", "altitude", "event_id"]

--- a/tests/utils/ais/test_timestamp_parsing.py
+++ b/tests/utils/ais/test_timestamp_parsing.py
@@ -97,7 +97,7 @@ class TestParseMxakAisTimestamps:
             ]
         )
         out = parse_mxak_ais_timestamps(time)
-        assert_series_equal(out, expected, check_dtype=False)
+        assert_series_equal(out, expected)
 
     def test_mixed_akst_akdt_march_dst_fallback(self):
         """March spring-forward day: mixed AKDT/AKST rows trigger DST fallback."""
@@ -115,7 +115,7 @@ class TestParseMxakAisTimestamps:
             ]
         )
         out = parse_mxak_ais_timestamps(time)
-        assert_series_equal(out, expected, check_dtype=False)
+        assert_series_equal(out, expected)
 
     def test_unrecognized_format_raises_value_error(self):
         time = pd.Series(["not-a-timestamp"])

--- a/tests/utils/ais/test_timestamp_parsing.py
+++ b/tests/utils/ais/test_timestamp_parsing.py
@@ -97,7 +97,7 @@ class TestParseMxakAisTimestamps:
             ]
         )
         out = parse_mxak_ais_timestamps(time)
-        assert_series_equal(out, expected)
+        assert_series_equal(out, expected, check_dtype=False)
 
     def test_mixed_akst_akdt_march_dst_fallback(self):
         """March spring-forward day: mixed AKDT/AKST rows trigger DST fallback."""
@@ -115,7 +115,7 @@ class TestParseMxakAisTimestamps:
             ]
         )
         out = parse_mxak_ais_timestamps(time)
-        assert_series_equal(out, expected)
+        assert_series_equal(out, expected, check_dtype=False)
 
     def test_unrecognized_format_raises_value_error(self):
         time = pd.Series(["not-a-timestamp"])


### PR DESCRIPTION
## Summary
- Update AIS/NVSPL test fixture paths to match the `example_data/` layout from #74 (`MXAK-AIS-GLBA/`, `nvspl_archive/...`).
- Add `psycopg2-binary` and pin `pandas>=2.2,<3` in the GitHub Actions workflow so CI matches local dev expectations. (This should be updated in the future)
- Broaden scipy spline error handling for duplicate `point_dt` values and relax datetime dtype checks in DST fallback timestamp tests.

## Follow-ups
I'll work on prepping a change to allow package-style installs from the `pyproject.toml` so we can just do a `pip install -e ".[dev]"` in the CI instead of these manually specified, unpinned dependencies. I'll look to do this as a next follow-up PR(s) as I would like to make the CI setup more robust.

## Test plan
- [x] `pytest tests/` passes locally (80 tests)
- [x] GitHub Actions workflow passes on this PR
