### PR TITLE
Replace print() with logging in library modules

### DIFF
--- a/nps_active_space/active_space/active_space_generator.py
+++ b/nps_active_space/active_space/active_space_generator.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import multiprocessing as mp
 import os
 import subprocess
@@ -38,6 +39,8 @@ human_hearing_threshold = pd.Series({
     "2500": -4.2, "3150": -6.0, "4000": -5.4, "5000": -1.5, "6300": 6.0, "8000": 12.6,
     "10000": 13.9, "12500": 12.3
 })
+
+logger = logging.getLogger(__name__)
 
 class PolygonCreationError(Exception):
     pass
@@ -647,7 +650,7 @@ class ActiveSpaceGenerator:
             stdout, stderr = process.communicate()
             if stderr:
                 for s in stderr.decode("utf-8").split("\r\n"):
-                    print(s.strip())
+                    logger.error(s.strip())
 
             # Read NMSIM outputs and remove unneeded .trj and .tis file
             new_nmsim_df = self._postprocess_trj_tis(
@@ -849,7 +852,7 @@ class ActiveSpaceGenerator:
             
             source_pts = self._preprocess_source_points(source_pts, valid_query_region, tested_pts)
             if source_pts.empty:
-                print(f"Mesh step {j+1}: no source points, skipping")
+                logger.info(f"Mesh step {j+1}: no source points, skipping")
                 break
             
             new_audibility_pts = self._run_nmsim(
@@ -1011,7 +1014,7 @@ class ActiveSpaceGenerator:
 
         pbar = tqdm(desc='Study Area', unit='study area', colour='green', total=study_areas.shape[0], leave=True)
         _update_pbar = lambda _: pbar.update()
-        _handle_error = lambda error: print(f'Error: {error}', flush=True)
+        _handle_error = lambda error: logger.error(f'Error: {error}')
 
         with mp.Pool(n_cpus) as pool:
             processes = []

--- a/nps_active_space/active_space/layered_active_space.py
+++ b/nps_active_space/active_space/layered_active_space.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import os
 import geopandas as gpd
@@ -7,6 +8,8 @@ import matplotlib.pyplot as plt
 from tqdm import tqdm
 from shapely.geometry import Point
 from nps_active_space.utils.computation import normalize_point_density
+
+logger = logging.getLogger(__name__)
 
 
 class LayeredActiveSpace():
@@ -41,7 +44,7 @@ class LayeredActiveSpace():
         for altitude, dir in self.layer_dirs.items():
             glob_result = glob.glob(os.path.join(dir, f"*_O_{sign}{gain_string}.geojson"))
             if len(glob_result) == 0:
-                print(f"Couldn't find active space for gain {gain} in {dir}")
+                logger.warning(f"Couldn't find active space for gain {gain} in {dir}")
                 return
             activespace_file = glob_result[0]
             activespaces[altitude] = gpd.read_file(activespace_file).to_crs(self.crs)
@@ -81,11 +84,11 @@ class LayeredActiveSpace():
         if points.crs != self.crs:
             points = points.to_crs(self.crs)
         
-        print("Assigning points to their closest layer")
+        logger.info("Assigning points to their closest layer")
         points = self.assign_layers(points)
 
         # Compute precision, recall, and F-Beta for each gain
-        print(f"Computing performance for each gain {min_gain}dB to {max_gain}dB")
+        logger.info(f"Computing performance for each gain {min_gain}dB to {max_gain}dB")
         detection_results = pd.DataFrame([])
         self.fit_pbar = tqdm(np.arange(min_gain, max_gain + 0.5, 0.5), unit=" Gain Values")
         for gain in self.fit_pbar:
@@ -115,7 +118,7 @@ class LayeredActiveSpace():
 
         best_gain = detection_results[f"F{beta}"].idxmax()
         best = detection_results.loc[best_gain]
-        print(f"Best gain: {best_gain}dB, F{beta} = {best[f"F{beta}"]}")
+        logger.info(f"Best gain: {best_gain}dB, F{beta} = {best[f"F{beta}"]}")
 
         self.set_gain(best_gain)
 

--- a/nps_active_space/utils/clock_drift.py
+++ b/nps_active_space/utils/clock_drift.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
@@ -15,7 +16,9 @@ from nps_active_space.utils.enums import TrackSource
 from nps_active_space.utils.models import FAAReleasable, Nvspl, Tracks
 from nps_active_space.utils.computation import expected_Lp, NMSIM_bbox_utm, audible_time_delay, ambience_from_nvspl, interpolate_spline
 from nps_active_space.utils.helpers import load_studyarea, get_deployment
-    
+
+logger = logging.getLogger(__name__)
+
 
 def logsum(df, axis=1):
     """Take a dataframe with columns representing SPL time series and logsum them together"""
@@ -71,14 +74,14 @@ class ClockDriftFixer():
         if plot_dir is not None:
             os.makedirs(plot_dir, exist_ok=True)
 
-        print("Loading site data")
+        logger.info("Loading site data")
         studyarea = load_studyarea(project_dir, unit, site, year)
         utm_zone = NMSIM_bbox_utm(studyarea)
         mic = get_deployment(project_dir, unit, site, year).to_crs(utm_zone)
         mic_pt = Point(mic.x, mic.y, mic.z)
         self.nvspl = nvspl
 
-        print("Filtering for only fixed-wing and helicopters")
+        logger.info("Filtering for only fixed-wing and helicopters")
         ids = pts["track_id"].str.split("_").str[0]  # ids will be either N-numbers or ICAO addresses
         uses_n_numbers = ids[0].startswith("N")
         if uses_n_numbers:
@@ -101,7 +104,7 @@ class ClockDriftFixer():
             pts.geometry.x, pts.geometry.y, pts.z)
         
         # Interpolate points. This is essential for GPS, and seems to help smooth stuff out for ADSB too
-        print("Interpolating points")
+        logger.info("Interpolating points")
         interp_list = []
         for track_id, group in pts.groupby("track_id"):
             if len(group) < 3:  # need at least 3 points to interpolate
@@ -112,12 +115,12 @@ class ClockDriftFixer():
         pts = pd.concat(interp_list, axis=0, ignore_index=True)
 
         # compute expected time and magnitude of audiblity
-        print("Computing audibility")
+        logger.info("Computing audibility")
         pts = expected_Lp(pts, mic_pt)
         pts = audible_time_delay(pts, "point_dt", mic_pt)
         self.pts = pts
 
-        print("Initialization Done")
+        logger.info("Initialization done")
 
 
     def get_clock_drift(self, start_dt, end_dt, max_clock_drift=pd.Timedelta(minutes=5)):
@@ -138,14 +141,14 @@ class ClockDriftFixer():
         # get the nvspl data corresponding to this time period
         full_index = pd.date_range(start_dt, end_dt, freq="s", inclusive="left")
         if len(self.nvspl.index.intersection(full_index)) < len(full_index):
-            print("NVSPL doesn't cover full period")
+            logger.warning("NVSPL doesn't cover full period")
             return np.nan
         nvspl_section = self.nvspl.loc[full_index]
 
         # get the track points corresponding to this time period
         pts_section = self.pts[(self.pts["point_dt"] > start_dt) & (self.pts["point_dt"] < end_dt)]
         if pts_section.empty:
-            print("No track points")
+            logger.warning("No track points")
             return np.nan
 
         # Correlating with NVSPL broadband SPL has issues with wind noise obscuring the aircraft signal.
@@ -207,7 +210,7 @@ class ClockDriftFixer():
             f"{len(correlation)} != {2 * max_clock_drift.total_seconds() + 1}"
         max_idx = np.argmax(correlation)
         if max_idx == 0 or max_idx == len(correlation)-1:
-            print("Max correlation at boundary, not true maximum")
+            logger.warning("Max correlation at boundary, not true maximum")
             return None  # boundary-limited, not true peak
         drifts = np.arange(-max_clock_drift.total_seconds(), max_clock_drift.total_seconds() + 1)
         clock_drift = drifts[max_idx]
@@ -260,7 +263,7 @@ class ClockDriftFixer():
         period_bounds = pd.date_range(start_dt.ceil(freq), end_dt.floor(freq), freq=freq)
         drifts = []
         for i in range(len(period_bounds)-1):
-            print(period_bounds[i], period_bounds[i+1])
+            logger.debug(f"{period_bounds[i]} to {period_bounds[i+1]}")
             drifts.append(self.get_clock_drift(period_bounds[i], period_bounds[i+1], max_clock_drift))
         
         # use the center of the period as the time anchor for each period's drift
@@ -364,12 +367,12 @@ class ClockDriftFixer():
             file_entries_list.append(pd.DataFrame({"Time": new_times, "Seconds": y_new}))
 
             plt.plot(new_times, y_new, color="black")
-            print(f"{period_start} to {period_end}, clock drift {slope:.3f} sec per day")
+            logger.info(f"{period_start} to {period_end}, clock drift {slope:.3f} sec per day")
         
         self.drift_fits = pd.DataFrame(fits_list)
         file_entries = pd.concat(file_entries_list, ignore_index=True)
         file_entries.to_csv(clock_drift_file, index=False)
-        print(file_entries)
+        logger.debug(f"Clock drift file entries:\n{file_entries}")
 
         if self.plot_dir is not None:
             plt.savefig(os.path.join(self.plot_dir, "Fitted Lines.png"))

--- a/nps_active_space/utils/computation.py
+++ b/nps_active_space/utils/computation.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import logging
 import math
 from typing import Iterable, List, Optional, Tuple, TYPE_CHECKING
 
@@ -16,6 +17,8 @@ from KDEpy import FFTKDE
 
 if TYPE_CHECKING:
     from nps_active_space.utils.models import Microphone, Nvspl, Tracks
+
+logger = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -566,7 +569,7 @@ def audibility_to_interval(aud, invert=False):
         # ...the last noise free interval stays the same, and equals zero
         # the rest are - 1
         save = nfi_ends[-1]
-        print(save)
+        logger.debug(f"NFI end boundary value: {save}")
         nfi_ends = nfi_ends - 1
         nfi_ends[-1] = save
 
@@ -694,7 +697,7 @@ def select_optimal(unit: str, site: str, year: int,
         detection_results.loc[omni, "gain"] = numeric_gain
 
         if verbose:
-            print(f"omni: {omni} --> F-{beta_}: {fbeta:0.3f} precision: {precision:0.3f} recall: {recall:0.3f}")
+            logger.info(f"omni: {omni} --> F-{beta_}: {fbeta:0.3f} precision: {precision:0.3f} recall: {recall:0.3f}")
         
         if fbeta > max_fbeta:
             max_fbeta = fbeta
@@ -791,7 +794,7 @@ def normalize_point_density(points: gpd.GeoDataFrame, study_area: gpd.GeoDataFra
     rng = np.random.default_rng(seed=random_seed)
     keep = rng.random(len(points)) <= p_keep
     points = points[keep]
-    print(f"Went from {n_before} to {len(points)} points when normalizing point density")
+    logger.info(f"Went from {n_before} to {len(points)} points when normalizing point density")
 
     if visualize:
         # run it again to visualize the difference

--- a/nps_active_space/utils/metrics.py
+++ b/nps_active_space/utils/metrics.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import pandas as pd
 import geopandas as gpd
@@ -14,6 +15,8 @@ import os
 from nps_active_space.utils.computation import contiguous_regions
 from nps_active_space.utils.models import Srcid
 import iyore
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     'clip_events_to_time_period',
@@ -70,7 +73,7 @@ def get_obs_periods(unit, site, year, nvspl_archive, adsb_dir=None):
         src_obj = Srcid(paths[0])
         src_obs_periods = src_obj.get_observation_periods()
     else:
-        print("No SPLAT annotation data")
+        logger.info("No SPLAT annotation data")
         src_obs_periods = None
 
     # load ADSB record periods if applicable
@@ -254,7 +257,7 @@ def get_noise_events(df, start_col, end_col, start_date, end_date, min_dur=10, m
     event_start_times = entry_times_cp[~short_events]
     event_end_times = exit_times_cp[~short_events]
     if short_events.sum() > 0:
-        print(f"Filtered out {short_events.sum()} events shorter than {min_dur} seconds")
+        logger.info(f"Filtered out {short_events.sum()} events shorter than {min_dur} seconds")
     
     # Account for event-less time at beginning and end of timeframe in question
     # This is needed for the inaudible_begins and inaudible_ends indices to match up properly so we can subtract to compute durations.
@@ -377,7 +380,7 @@ def _agg_conf_intervals(series: pd.Series, agg_funcs: list):
                                     confidence_level=0.95, n_resamples=1000, method="percentile")
             out[f.__name__] = result.confidence_interval
         except Exception as e:
-            print(f"Error with function {f.__name__}: {e}")
+            logger.error(f"Error with function {f.__name__}: {e}")
             out[f.__name__] = (pd.NA, pd.NA)
     return pd.Series(out)
 
@@ -435,7 +438,7 @@ def get_all_geo_stats(tracks, periods, months=list(range(1,13)), quantiles=.5):
     # Make sure months are between 1 and 12
     for month in months:
         if (month < 1) | (month > 12):
-            print("Warning: Invalid months. Must be a list of integers from 1-12. Ignoring months parameter...")
+            logger.warning("Invalid months. Must be a list of integers from 1-12. Ignoring months parameter.")
             months=list(range(1,13))
     
     # get events and NFIs for the whole study time
@@ -605,7 +608,7 @@ def get_all_srcid_stats(src_data, periods, months=list(range(1,13)), quantiles=.
     # Make sure months are between 1 and 12
     for month in months:
         if (month < 1) | (month > 12):
-            print("Warning: Invalid months. Must be a list of integers from 1-12. Ignoring months parameter...")
+            logger.warning("Invalid months. Must be a list of integers from 1-12. Ignoring months parameter.")
             months=list(range(1,13))
 
     # add start and end time fields
@@ -881,7 +884,7 @@ def endpoints_around_active(active, tracks, distance_delta, peak_distance, endpo
     elif endpoint_type == 'exit':
         peak_indices = find_circular_peaks(active_gdf.exits, distance_delta, peak_distance)
     else:
-        print("error: endpoint_type must be 'entry' or 'exit'")
+        logger.error("endpoint_type must be 'entry' or 'exit'")
         return 0
                                             
     return active_gdf, peak_indices
@@ -912,8 +915,8 @@ def identify_stereotypical_tracks(active, tracks, distance_delta=100, peak_dista
     peak_indices : numpy array of ints
         Array containing the indices of the peaks, sorted by descending peak height.
     '''
-    print("Identifying stereotypical tracks...")
-    print(" - finding common entries and exits")
+    logger.info("Identifying stereotypical tracks...")
+    logger.info("Finding common entries and exits")
     
     # Identify common entry points and generate segmented active space boundary
     active_gdf, peak_entry_indices = endpoints_around_active(active, tracks, distance_delta, peak_distance, endpoint_type='entry')
@@ -945,7 +948,7 @@ def identify_stereotypical_tracks(active, tracks, distance_delta=100, peak_dista
         common_endpoints_gdf = common_endpoints_gdf[common_endpoints_gdf.transit_length > 2000]
     common_endpoints_gdf = common_endpoints_gdf.sort_values(by='number_of_corresponding_tracks', ascending=False)
 
-    print(f" - of {len(common_endpoints_gdf)}, identifying possible stereotypical tracks")
+    logger.info(f"Of {len(common_endpoints_gdf)} candidates, identifying possible stereotypical tracks")
     
     all_tracks = tracks.copy()
     stereotype_locs = []   # list to store gdf indices of stereotypical tracks
@@ -967,11 +970,11 @@ def identify_stereotypical_tracks(active, tracks, distance_delta=100, peak_dista
         # Calculate number of tracks that could be bundled up with each possible stereotypical track
         possible_tracks['bundle_count'] = possible_tracks.interp_geometry.apply([lambda track: all_tracks.within(track.buffer(1000)).sum()])
         # The maximum bundle count for each entry/exit pair will be the representative track for a given path
-        print(len(possible_tracks), len(all_tracks))
+        logger.debug(f"Possible tracks: {len(possible_tracks)}, all tracks: {len(all_tracks)}")
         stereotype_locs.append(possible_tracks[possible_tracks.bundle_count == possible_tracks.bundle_count.max()].index[0])
         bundle_count.append(possible_tracks.bundle_count.max())
 
-    print(" - narrowing down results")
+    logger.info("Narrowing down results")
     
     stereotypical_tracks = all_tracks.loc[stereotype_locs]
     stereotypical_tracks['represents_pct'] = np.array(bundle_count)/len(all_tracks) * 100

--- a/nps_active_space/utils/models.py
+++ b/nps_active_space/utils/models.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from datetime import datetime
 from types import GeneratorType
@@ -23,6 +24,8 @@ import pandas as pd
 from .computation import contiguous_regions
 pd.options.mode.copy_on_write = True
 pd.set_option('future.no_silent_downcasting', True)
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     'Microphone',
@@ -149,7 +152,7 @@ class Nvspl(pd.DataFrame):
                             usecols=columns
                             )
         except Exception as e:
-            print(f" (!!!) Error occurred reading {nvsplFileEntry}")
+            logger.error(f"Error occurred reading {nvsplFileEntry}")
             raise e
 
         # Make column names slightly nicer
@@ -353,7 +356,7 @@ class Adsb(gpd.GeoDataFrame):
 
         dataframes = []
         for dir in dirs:
-            print(f"Loading ADSB files in {dir}")
+            logger.info(f"Loading ADSB files in {dir}")
             dir_files = dirs[dir]
 
             # attempt to load that directory's index file (which may or may not exist)
@@ -1165,7 +1168,7 @@ class FAAReleasable():
         to_save["database_last_modified"] = os.path.getmtime(self.FAA_path)
         with open(self.index_path, "w") as f:
             json.dump(to_save, f)
-        print(
+        logger.info(
             f"Saved FAA database index to {os.path.abspath(self.index_path)}")
 
         # filter data

--- a/nps_active_space/validation/study_duration_stability.py
+++ b/nps_active_space/validation/study_duration_stability.py
@@ -1,3 +1,4 @@
+import logging
 import geopandas as gpd
 from tqdm import tqdm
 import pandas as pd
@@ -9,6 +10,8 @@ import os
 from shapely.geometry import Point
 from nps_active_space.utils.helpers import load_annotations, load_studyarea, load_layered_activespace
 from nps_active_space.utils.computation import normalize_point_density, NMSIM_bbox_utm
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "get_csv_name",
@@ -44,11 +47,11 @@ def fit_varying_n_tracks(project_dir, unit, site, year):
         Year as a string. E.g. "2025".
     """
     deployment = f"{unit}{site}{year}"
-    print(deployment)
+    logger.info(f"Processing deployment: {deployment}")
 
     savefile = get_csv_name(project_dir, unit+site+year)
     if os.path.exists(savefile):
-        print(f"Skipping, found existing results in {savefile}")
+        logger.info(f"Skipping, found existing results in {savefile}")
         return
 
     study_area = load_studyarea(project_dir, unit, site, year)
@@ -73,7 +76,7 @@ def fit_varying_n_tracks(project_dir, unit, site, year):
     areas = {}
     layers = list(model.layer_dirs.keys())
     mid_layer = layers[len(layers) // 2]
-    print(f"Using {mid_layer}m for areas")
+    logger.info(f"Using {mid_layer}m for areas")
     for gain in tqdm(model.all_activespaces, desc="Computing areas"):
         active = model.all_activespaces[gain][mid_layer]
         active_equal_area = active.to_crs("epsg:3338")  # albers AK equal area
@@ -148,11 +151,11 @@ def fit_varying_n_tracks(project_dir, unit, site, year):
     
     # Convert results to proper dataframe and save
     results = pd.DataFrame(result_rows)
-    print(results)
+    logger.info(f"Results:\n{results}")
 
     os.makedirs(os.path.dirname(savefile), exist_ok=True)
     results.to_csv(savefile, index=False)
-    print(f"Saved to {savefile}")
+    logger.info(f"Saved to {savefile}")
 
 
 
@@ -238,4 +241,4 @@ def plot_stability(project_dir, deployments, col="area", top_k=10, max_n_tracks=
     else:
         filename = os.path.join(project_dir, f"{col}_stability.png")
     plt.savefig(filename)
-    print(f"Saved plot to {filename}")
+    logger.info(f"Saved plot to {filename}")


### PR DESCRIPTION
The utils/ and active_space/ library modules use raw print() for diagnostic messages. This swaps them for logging.getLogger(__name__) so callers can control verbosity, and messages can be directed to log files instead of just stdout.

Only touches library modules. Scripts like run_audible_transits.py already create their own loggers via get_logger() and are unchanged.