### PR TITLE
Document config template with inline comments

### DIFF
--- a/nps_active_space/config/template.config
+++ b/nps_active_space/config/template.config
@@ -1,20 +1,53 @@
+# NPS-ActiveSpace configuration template.
+# Copy this file and rename it to <environment>.config (e.g. DENA.config),
+# then fill in the values for your deployment.
+# Usage: pass the environment name via -e, e.g. -e DENA
+
+# PostgreSQL connection for the overflights database.
+# Only needed for database-sourced tracks in run_ground_truthing.py
+# and run_audible_transits.py. Leave blank to use file-based tracks.
 [database:overflights]
 name =
 username =
 password =
-port =
-host =
+port = 5432
+host = localhost
 
+# Paths to input data sources.
 [data]
+# File containing site deployment metadata (coordinates, dates, etc.).
+# Required for run_ground_truthing.py and generate_active_space.py.
 site_metadata =
+# Root directory of the NVSPL sound pressure level archive.
+# Required for run_ground_truthing.py and generate_active_space.py.
 nvspl_archive =
+# Directory containing ADS-B aircraft track CSV files.
+# Required when using ADS-B tracks in run_ground_truthing.py
+# or run_audible_transits.py.
 adsb =
+# Directory containing MXAK AIS vessel track data.
+# Required when using AIS tracks in run_ground_truthing.py.
 ais =
+# Path to a DEM GeoTIFF covering the study area.
+# Required for generate_active_space.py and generate_active_space_mesh.py.
 dem =
+# Path to the Mennitt ambient sound level GeoTIFF.
+# Required for generate_active_space.py and generate_active_space_mesh.py.
 mennitt =
 
+# Project output paths and supporting files.
 [project]
+# Root directory for site project folders (each named UNITSITE, e.g. DENATRLA).
+# Required for all scripts.
 dir =
+# Path to the NMSIM Nord2000batch executable.
+# Required for generate_active_space.py and generate_active_space_mesh.py.
 nmsim =
-FAA_Releasable_db = 
-FAA_type_corrections = 
+# Path to the FAA Releasable Aircraft Database MASTER.txt file,
+# from https://www.faa.gov/licenses_certificates/aircraft_certification/aircraft_registry/releasable_aircraft_download
+# Required for run_audible_transits.py.
+FAA_Releasable_db =
+# Path to a JSON file with ICAO address corrections for aircraft types.
+# Keys are ICAO hex addresses, values are corrected aircraft type strings.
+# Required for run_ground_truthing.py and run_audible_transits.py.
+FAA_type_corrections =


### PR DESCRIPTION
Addresses #54.

The existing template.config has all the right keys but no inline docs, so you have to cross-reference the README while filling it out. This adds comments to the template explaining what each key is for and which scripts need it.

No code changes. Just documentation in the config file itself. The example configs from #74 already cover the filled-out reference case.