### PR TITLE
Fix mutable default argument in build_annotation_segments

### DIFF
--- a/nps_active_space/ground_truthing/segments.py
+++ b/nps_active_space/ground_truthing/segments.py
@@ -46,7 +46,7 @@ def collapse_audible_ranges(ranges: list[AudibleRange]) -> list[AudibleRange]:
 def build_annotation_segments(
     track_id: str,
     points: gpd.GeoDataFrame,
-    audible_ranges: list[AudibleRange] = [],
+    audible_ranges: list[AudibleRange] | None = None,
     valid: bool = True,
     note: str | None = None,
 ) -> gpd.GeoDataFrame:
@@ -61,11 +61,14 @@ def build_annotation_segments(
         Track and spline points to annotate.
     valid : bool, default True
         If the track was valid.
-    audible_ranges: list of [datetime, datetime], default []
-        Periods of time when the track was audible. If an empty list, everything was inaudible.        
+    audible_ranges: list of [datetime, datetime], default None
+        Periods of time when the track was audible. If None or empty, everything was inaudible.
     note: str, default None
         Any note to be added to all points passed for annotation.
     """
+    if audible_ranges is None:
+        audible_ranges = []
+
     # Convert points to WGS84 to avoid geopandas bug mentioned in Track model :(
     if 'z' not in points.columns:
         points['z'] = points.geometry.z

--- a/tests/ground_truthing/test_segments.py
+++ b/tests/ground_truthing/test_segments.py
@@ -34,6 +34,17 @@ class TestCollapseAudibleRanges:
         ranges = [[t0, t0 + dt.timedelta(minutes=3)]]
         assert collapse_audible_ranges(ranges) == ranges
 
+    def test_empty_input(self):
+        assert collapse_audible_ranges([]) == []
+
+    def test_adjacent_ranges_stay_separate(self):
+        t0 = dt.datetime(2020, 1, 1, 12, 0, 0)
+        ranges = [
+            [t0, t0 + dt.timedelta(minutes=3)],
+            [t0 + dt.timedelta(minutes=3), t0 + dt.timedelta(minutes=6)],
+        ]
+        assert collapse_audible_ranges(ranges) == [[t0, t0 + dt.timedelta(minutes=6)]]
+
 
 class TestBuildAnnotationSegments:
     def test_all_inaudible_when_no_ranges(self):
@@ -146,6 +157,14 @@ class TestBuildAnnotationSegments:
             }
         )
         assert_frame_equal(actual, expected, check_dtype=False)
+
+    def test_default_audible_ranges_not_shared_across_calls(self):
+        """Calling without audible_ranges should never leak state between calls."""
+        points = make_track_points(3)
+        build_annotation_segments("T1", points)
+        result = build_annotation_segments("T2", points)
+        assert len(result) == 1
+        assert result.audible.iat[0] is False
 
     def test_note_propagates_to_segments(self):
         points = make_track_points(6)


### PR DESCRIPTION
The `audible_ranges` parameter in `build_annotation_segments()` defaults to a mutable list `[]`. In Python, mutable defaults are shared across all calls to the function, so if any caller ever modified it in place the default would be permanently changed for subsequent calls.

The fix replaces the default with `None` and initializes a fresh list inside the function body. This is a standard Python pattern for avoiding the mutable default gotcha.

Also adds a few tests:
- Verifies the default isn't shared across consecutive calls
- Covers `collapse_audible_ranges` with empty input and adjacent ranges (where end == start of the next, which the counter-based algorithm correctly merges)