### PR TITLE
Fix mutable defaults, debug print, and duplicate imports

### DIFF
--- a/nps_active_space/scripts/run_audible_transits.py
+++ b/nps_active_space/scripts/run_audible_transits.py
@@ -36,7 +36,7 @@ from nps_active_space.utils.models import Tracks, FAAReleasable
 
 pd.set_option('future.no_silent_downcasting', True)
 
-def init_audible_transits(metadata, paths={}, raw_tracks = None):
+def init_audible_transits(metadata, paths=None, raw_tracks=None):
     '''
     Main function for initialization. Decides which AudibleTransits subclass to initialize based on the metadata provided.
 
@@ -86,6 +86,8 @@ def init_audible_transits(metadata, paths={}, raw_tracks = None):
     ValueError if invalid database type is entered
     '''
 
+    if paths is None:
+        paths = {}
     assert "database type" in metadata, "Metadata must contain a 'database type' field"
 
     if metadata["database type"] == "ADSB":

--- a/nps_active_space/utils/clock_drift.py
+++ b/nps_active_space/utils/clock_drift.py
@@ -7,9 +7,6 @@ from shapely.geometry import Point
 import os
 from scipy.signal import correlate
 from scipy.ndimage import sobel
-import pandas as pd
-import numpy as np
-from shapely.geometry import Point
 
 from nps_active_space.utils.enums import TrackSource
 from nps_active_space.utils.models import FAAReleasable, Nvspl, Tracks

--- a/nps_active_space/utils/computation.py
+++ b/nps_active_space/utils/computation.py
@@ -566,7 +566,6 @@ def audibility_to_interval(aud, invert=False):
         # ...the last noise free interval stays the same, and equals zero
         # the rest are - 1
         save = nfi_ends[-1]
-        print(save)
         nfi_ends = nfi_ends - 1
         nfi_ends[-1] = save
 

--- a/nps_active_space/utils/metrics.py
+++ b/nps_active_space/utils/metrics.py
@@ -127,7 +127,7 @@ def get_obs_periods(unit, site, year, nvspl_archive, adsb_dir=None):
         return np.datetime_as_string(obs_periods, unit="D")
 
 
-def clip_events_to_time_period(df, start_col, end_col, start_dt, end_dt, months=list(range(1,13))):
+def clip_events_to_time_period(df, start_col, end_col, start_dt, end_dt, months=None):
     """Clips events to only fall within a time period and within ceratin months.
     Events that partially overlap the time period boundaries are shortened to only include the section within the time period.
     
@@ -152,6 +152,8 @@ def clip_events_to_time_period(df, start_col, end_col, start_dt, end_dt, months=
         A copy of the input DataFrame, only containing the events within the time period,
         with modified start / end times if the event overlapped the time period boundaries.
     """
+    if months is None:
+        months = list(range(1, 13))
     df = df.copy()
     during_time_period = (df[end_col] > start_dt) & (df[start_col] < end_dt)
     during_correct_months = df[start_col].dt.month.isin(months) | df[end_col].dt.month.isin(months)
@@ -395,9 +397,9 @@ class Quantile:
 
 # GEOGRAPHIC --------------------------------------------------------------
 
-def get_all_geo_stats(tracks, periods, months=list(range(1,13)), quantiles=.5):
+def get_all_geo_stats(tracks, periods, months=None, quantiles=.5):
     """Calculates all event statistics, given tracks from the Audible Transits module.
-    
+
     Parameters
     ----------
     tracks: gpd.GeoDataFrame
@@ -406,17 +408,17 @@ def get_all_geo_stats(tracks, periods, months=list(range(1,13)), quantiles=.5):
         containing a start and end date string formatted 'yyyy-mm-dd'. The start and end dates are included in the period.
         This is important for stats like NFI and time audible.
     months : int or list of ints (between 1 and 12)
-        Default is the full year, an optional input to specify the months of interest as a list of integers, 1-12. 
+        Default is the full year, an optional input to specify the months of interest as a list of integers, 1-12.
         This is helpful for highly seasonal flight patterns, such as Denali's summer vs winter splits.
     quantiles : float or list of floats (between 0 and 1)
         Default is .5 (the median), specifies which quantiles to output. E.g., [.1, .5., .9] will output 10th, 50th, and 90th quantiles
-    
+
     Returns
     -------
     statistics: pd.DataFrame.
         DataFrame containing computed statistics.
         Columns represent the metrics that statistics are computed for: event_duration, NFI_duration, daily_time_audible, daily_event_count, hourly_time_audible, hourly_event_count
-        Rows represent the statistic: mean, quantiles, min, max, std, median_abs_deviation 
+        Rows represent the statistic: mean, quantiles, min, max, std, median_abs_deviation
 
     confidence_intervals: pd.DataFrame.
         DataFrame containing 95% percentile confidence intervals for the mean and quantiles, computed using bootstrapping.
@@ -429,8 +431,10 @@ def get_all_geo_stats(tracks, periods, months=list(range(1,13)), quantiles=.5):
     """
 
     # Input validation. Both 'quantiles' and 'months' parameters must be converted to lists
-    quantiles = [quantiles] if type(quantiles)!=type([]) else quantiles
-    months = [months] if type(months)!=type([]) else months
+    if months is None:
+        months = list(range(1, 13))
+    quantiles = [quantiles] if not isinstance(quantiles, list) else quantiles
+    months = [months] if not isinstance(months, list) else months
 
     # Make sure months are between 1 and 12
     for month in months:
@@ -538,14 +542,16 @@ def calculate_spatial_stats(tracks, active):
 
 # ACOUSTIC ----------------------------------------------------------------
 
-def clip_srcid_to_time_period(src_data, start_dt, end_dt, months=list(range(1,13))):
+def clip_srcid_to_time_period(src_data, start_dt, end_dt, months=None):
     """A wrapper function around `clip_events_to_time_period` to clip SRCID data.
     Requires src_data to have fields "start_time" and "end_time"
     """
 
+    if months is None:
+        months = list(range(1, 13))
     assert "start_time" in src_data.columns
     assert "end_time" in src_data.columns
-    
+
     src_clipped = clip_events_to_time_period(src_data,
                                              start_col = "start_time",
                                              end_col = "end_time",
@@ -560,7 +566,7 @@ def clip_srcid_to_time_period(src_data, start_dt, end_dt, months=list(range(1,13
     return src_clipped
 
 
-def get_all_srcid_stats(src_data, periods, months=list(range(1,13)), quantiles=.5, src_list=[1.2]):
+def get_all_srcid_stats(src_data, periods, months=None, quantiles=.5, src_list=None):
     """Calculates all event statistics, given a set of events and corresponding noise free intervals (NFIs).
     
     Parameters
@@ -599,14 +605,18 @@ def get_all_srcid_stats(src_data, periods, months=list(range(1,13)), quantiles=.
     """
 
     # Input validation. Both 'quantiles' and 'months' parameters must be converted to lists
-    quantiles = [quantiles] if type(quantiles)!=type([]) else quantiles
-    months = [months] if type(months)!=type([]) else months
+    if months is None:
+        months = list(range(1, 13))
+    if src_list is None:
+        src_list = [1.2]
+    quantiles = [quantiles] if not isinstance(quantiles, list) else quantiles
+    months = [months] if not isinstance(months, list) else months
 
     # Make sure months are between 1 and 12
     for month in months:
         if (month < 1) | (month > 12):
             print("Warning: Invalid months. Must be a list of integers from 1-12. Ignoring months parameter...")
-            months=list(range(1,13))
+            months = list(range(1, 13))
 
     # add start and end time fields
     src_data = src_data.copy()


### PR DESCRIPTION
Fixes a few related code quality issues across the codebase.

**Mutable default arguments** - five function signatures used mutable lists or dicts as defaults (metrics.py: clip_events_to_time_period, get_all_geo_stats, clip_srcid_to_time_period, get_all_srcid_stats; run_audible_transits.py: init_audible_transits). Replaced with None + initialization inside the function body.

**type() comparisons** - get_all_geo_stats and get_all_srcid_stats used `type(x)!=type([])` to check if a parameter was a list. Replaced with `isinstance()` which also handles subclasses correctly.

**Debug print** - `print(save)` left in computation.py audibility_to_interval() at the end of the noise-free interval calculation. Removed.

**Duplicate imports** - clock_drift.py imported pandas, numpy, and shapely.geometry.Point twice each. Removed the duplicates.