### PR TITLE
Remove unused imports

### DIFF
--- a/nps_active_space/active_space/active_space_generator.py
+++ b/nps_active_space/active_space/active_space_generator.py
@@ -4,7 +4,7 @@ import multiprocessing as mp
 import os
 import subprocess
 from functools import partial
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 from uuid import uuid4
 
 import geopandas as gpd
@@ -15,7 +15,7 @@ import pandas as pd
 from osgeo import gdal
 from pyproj import Transformer
 import rasterio
-from shapely.geometry import Point, Polygon, box
+from shapely.geometry import Polygon, box
 from shapely.validation import make_valid
 from tqdm import tqdm
 from warnings import warn

--- a/nps_active_space/scripts/get_geographic_metrics.py
+++ b/nps_active_space/scripts/get_geographic_metrics.py
@@ -3,7 +3,7 @@ import pandas as pd
 from argparse import ArgumentParser
 import matplotlib.pyplot as plt
 import pickle
-from nps_active_space.scripts.run_audible_transits import init_audible_transits, AudibleTransits, AudibleTransitsADSB, AudibleTransitsGPS
+from nps_active_space.scripts.run_audible_transits import init_audible_transits, AudibleTransits
 from nps_active_space.utils.enums import TrackSource
 from nps_active_space.utils.metrics import get_obs_periods, get_all_geo_stats
 import nps_active_space.utils.config as cfg

--- a/nps_active_space/scripts/run_audible_transits.py
+++ b/nps_active_space/scripts/run_audible_transits.py
@@ -1,6 +1,5 @@
 import os
 import copy
-import sqlalchemy
 from scipy.ndimage import median_filter
 import pickle
 import pandas as pd
@@ -31,7 +30,7 @@ from nps_active_space.utils.helpers import (
     load_activespace,
     load_layered_activespace,
 )
-from nps_active_space.utils.computation import NMSIM_bbox_utm, contiguous_regions, coords_to_utm, interpolate_spline
+from nps_active_space.utils.computation import NMSIM_bbox_utm, contiguous_regions, interpolate_spline
 from nps_active_space.utils.models import Tracks, FAAReleasable
 
 pd.set_option('future.no_silent_downcasting', True)

--- a/nps_active_space/scripts/viz.py
+++ b/nps_active_space/scripts/viz.py
@@ -6,7 +6,6 @@ import glob
 import pyvista as pv
 import rasterio
 import pyproj
-import sys
 from shapely.geometry import box, Polygon, MultiPolygon, LineString, MultiLineString
 from nps_active_space.utils.helpers import get_deployment, load_annotations, load_DEM, load_layered_activespace, load_studyarea
 from nps_active_space.scripts.run_audible_transits import AudibleTransits


### PR DESCRIPTION
Cleans up imports that are no longer referenced in the codebase. Optional to merge.

- active_space_generator.py: Iterable, List (typing), and Point (shapely) are imported but never used
- run_audible_transits.py: sqlalchemy is imported at the top level but never referenced. coords_to_utm is imported from computation but never called anywhere in the file.
- get_geographic_metrics.py: AudibleTransitsADSB and AudibleTransitsGPS are imported but only AudibleTransits and init_audible_transits are actually used
- viz.py: sys is imported but never used

Caught these while reading through the codebase. No behavioral changes.