### PR TITLE
Add type annotations to metrics.py

### DIFF
--- a/nps_active_space/utils/metrics.py
+++ b/nps_active_space/utils/metrics.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
 import logging
 import numpy as np
 import pandas as pd
@@ -37,7 +40,7 @@ __all__ = [
 
 # SHARED - ACOUSTIC AND GEOGRAPHIC ---------------------------------------
 
-def get_obs_periods(unit, site, year, nvspl_archive, adsb_dir=None):
+def get_obs_periods(unit: str, site: str, year: str, nvspl_archive: str, adsb_dir: str | None = None) -> np.ndarray:
     """
     Get periods of time in which we have overlapping acoustic and causal observations.
     A full day with no SPLAT annotations is considered acoustic data missing.
@@ -130,7 +133,7 @@ def get_obs_periods(unit, site, year, nvspl_archive, adsb_dir=None):
         return np.datetime_as_string(obs_periods, unit="D")
 
 
-def clip_events_to_time_period(df, start_col, end_col, start_dt, end_dt, months=list(range(1,13))):
+def clip_events_to_time_period(df: pd.DataFrame, start_col: str, end_col: str, start_dt: np.datetime64, end_dt: np.datetime64, months: list[int] = list(range(1,13))) -> pd.DataFrame:
     """Clips events to only fall within a time period and within ceratin months.
     Events that partially overlap the time period boundaries are shortened to only include the section within the time period.
     
@@ -165,7 +168,7 @@ def clip_events_to_time_period(df, start_col, end_col, start_dt, end_dt, months=
     return df
 
 
-def get_noise_events(df, start_col, end_col, start_date, end_date, min_dur=10, min_gap_dur=30):
+def get_noise_events(df: pd.DataFrame, start_col: str, end_col: str, start_date: str, end_date: str, min_dur: int = 10, min_gap_dur: int = 30) -> tuple[pd.DataFrame, pd.DataFrame, float]:
     """
     Converts a set of events that might overlap into a sequence of non-overlapping events,
     separated by a minimum separation duration. Also filters out short events.
@@ -286,7 +289,7 @@ def get_noise_events(df, start_col, end_col, start_date, end_date, min_dur=10, m
     return event_df, NFI_df, TA
 
 
-def _split_events(df, freq):
+def _split_events(df: pd.DataFrame, freq: str) -> pd.DataFrame:
     """Split events that span hour/day/etc boundaries into consecutive events.
     
     Parameters
@@ -322,7 +325,7 @@ def _split_events(df, freq):
     return pd.DataFrame(split_rows)
 
 
-def _time_binned_df(event_df, start_dt, end_dt, months, freq):
+def _time_binned_df(event_df: pd.DataFrame, start_dt: np.datetime64, end_dt: np.datetime64, months: list[int], freq: str) -> pd.DataFrame:
     """Calculates time audible and event count for each time chunk (e.g. hourly) in a given time period.
     
     Parameters
@@ -372,7 +375,7 @@ def _time_binned_df(event_df, start_dt, end_dt, months, freq):
     return periods_df
 
 
-def _agg_conf_intervals(series: pd.Series, agg_funcs: list):
+def _agg_conf_intervals(series: pd.Series, agg_funcs: list) -> pd.Series:
     out = {}
     for f in agg_funcs:
         try:
@@ -388,17 +391,17 @@ def _agg_conf_intervals(series: pd.Series, agg_funcs: list):
 # nice trick for aggregating quantiles cleanly, inspired from here:
 # https://skeptric.com/pandas-aggregate-quantile/
 class Quantile:
-    def __init__(self, q):
+    def __init__(self, q: float) -> None:
         self.q = q
         self.__name__ = f"{int(100*q)}% quantile"
-    
-    def __call__(self, series: pd.Series):
+
+    def __call__(self, series: pd.Series) -> float:
         return series.quantile(self.q)
 
 
 # GEOGRAPHIC --------------------------------------------------------------
 
-def get_all_geo_stats(tracks, periods, months=list(range(1,13)), quantiles=.5):
+def get_all_geo_stats(tracks: gpd.GeoDataFrame, periods: np.ndarray, months: list[int] = list(range(1,13)), quantiles: float | list[float] = .5) -> tuple[pd.DataFrame, pd.DataFrame, dict]:
     """Calculates all event statistics, given tracks from the Audible Transits module.
     
     Parameters
@@ -495,7 +498,7 @@ def get_all_geo_stats(tracks, periods, months=list(range(1,13)), quantiles=.5):
     return pd.DataFrame(statistics), pd.DataFrame(conf_intervals), values    
 
 
-def calculate_spatial_stats(tracks, active):
+def calculate_spatial_stats(tracks: gpd.GeoDataFrame, active: gpd.GeoDataFrame) -> pd.DataFrame:
     '''
     Calculates spatial statistics on audible transits through a given active space. 
     On an event-wise basis, the displacement distance that could render the track inaudible:
@@ -541,7 +544,7 @@ def calculate_spatial_stats(tracks, active):
 
 # ACOUSTIC ----------------------------------------------------------------
 
-def clip_srcid_to_time_period(src_data, start_dt, end_dt, months=list(range(1,13))):
+def clip_srcid_to_time_period(src_data: pd.DataFrame, start_dt: np.datetime64, end_dt: np.datetime64, months: list[int] = list(range(1,13))) -> pd.DataFrame:
     """A wrapper function around `clip_events_to_time_period` to clip SRCID data.
     Requires src_data to have fields "start_time" and "end_time"
     """
@@ -563,7 +566,7 @@ def clip_srcid_to_time_period(src_data, start_dt, end_dt, months=list(range(1,13
     return src_clipped
 
 
-def get_all_srcid_stats(src_data, periods, months=list(range(1,13)), quantiles=.5, src_list=[1.2]):
+def get_all_srcid_stats(src_data: pd.DataFrame, periods: np.ndarray, months: list[int] = list(range(1,13)), quantiles: float | list[float] = .5, src_list: list[float] = [1.2]) -> tuple[pd.DataFrame, pd.DataFrame, dict]:
     """Calculates all event statistics, given a set of events and corresponding noise free intervals (NFIs).
     
     Parameters
@@ -684,7 +687,7 @@ def get_all_srcid_stats(src_data, periods, months=list(range(1,13)), quantiles=.
 
 ## ========================================== VISUALIZATION =============================================== ##
 
-def _split_interval_by_hour(start, end):
+def _split_interval_by_hour(start: pd.Timestamp, end: pd.Timestamp) -> Iterator[tuple[pd.Timestamp, pd.Timestamp]]:
     """Yield (segment_start, segment_end) tuples split at each hour boundary."""
     while start < end:
         next_hour = (start + timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
@@ -693,7 +696,7 @@ def _split_interval_by_hour(start, end):
         start = segment_end
         
 
-def plot_events(start_times, end_times, title="Events", colors=None, labels=False, savepath=None):
+def plot_events(start_times: pd.Series, end_times: pd.Series, title: str = "Events", colors: list | None = None, labels: bool = False, savepath: str | None = None) -> None:
     """Plot events on a timeline that wraps around at each hour.
     
     Parameters
@@ -755,7 +758,7 @@ def plot_events(start_times, end_times, title="Events", colors=None, labels=Fals
 
 ## ========================================== STEREOTYPICAL TRACKS ======================================== ##
 
-def circular_sliding_avg(vector, window_len):
+def circular_sliding_avg(vector: np.ndarray, window_len: int) -> np.ndarray:
     '''
     Smooth circular data by calculating sliding averages on a circular array. 
     Used to create an integrated map of entry/exit points around the boundary of an active space.
@@ -782,7 +785,7 @@ def circular_sliding_avg(vector, window_len):
     return smoothed
 
 
-def find_circular_peaks(column, distance_delta, peak_distance):
+def find_circular_peaks(column: pd.Series, distance_delta: int, peak_distance: int) -> np.ndarray:
     '''
     A specific adaptation of SciPy.Signal's 'find_peaks' algorithm for use on an active space polygon.
     Critical to implementation is the ability to wrap the input array. In this case, we use a minimum-distance
@@ -825,7 +828,7 @@ def find_circular_peaks(column, distance_delta, peak_distance):
     return sorted_peak_indices
 
 
-def endpoints_around_active(active, tracks, distance_delta, peak_distance, endpoint_type):
+def endpoints_around_active(active: gpd.GeoDataFrame, tracks: gpd.GeoDataFrame, distance_delta: int, peak_distance: int, endpoint_type: str) -> tuple[gpd.GeoDataFrame, np.ndarray]:
     '''
     Function to calculate the position of the most frequent entry and exit points through an active space.
     (e.g., transportation fluxes along the polygon). A sliding average is applied to spatially smooth
@@ -890,7 +893,7 @@ def endpoints_around_active(active, tracks, distance_delta, peak_distance, endpo
     return active_gdf, peak_indices
 
 
-def identify_stereotypical_tracks(active, tracks, distance_delta=100, peak_distance=1000):
+def identify_stereotypical_tracks(active: gpd.GeoDataFrame, tracks: gpd.GeoDataFrame, distance_delta: int = 100, peak_distance: int = 1000) -> gpd.GeoDataFrame:
     '''
     Function to identify stereotypical tracks across an active space. 
     Picks out specific paths that closely resemble the most tracks.


### PR DESCRIPTION
Adds type annotations to all 18 functions (and the Quantile helper class)
in metrics.py, which previously had zero annotation coverage. Uses
`from __future__ import annotations` for native 3.12+ syntax.

Changes:

- Parameter and return type annotations for all public functions:
  get_obs_periods, clip_events_to_time_period, get_noise_events,
  get_all_geo_stats, calculate_spatial_stats, clip_srcid_to_time_period,
  get_all_srcid_stats, plot_events, circular_sliding_avg,
  find_circular_peaks, endpoints_around_active, identify_stereotypical_tracks
- Internal helpers annotated too: _split_events, _time_binned_df,
  _agg_conf_intervals, _split_interval_by_hour
- Quantile class methods annotated with __init__ -> None and __call__ -> float
- Added `Iterator` import from collections.abc for the generator function

Similar in style to #98 (computation.py) and #91 (layered_active_space.py).
No runtime behavior changes.