### PR TITLE
Fix correct_clock_drift(inplace=False) returning the function instead of corrected times

### DIFF
--- a/nps_active_space/utils/clock_drift.py
+++ b/nps_active_space/utils/clock_drift.py
@@ -430,5 +430,5 @@ def correct_clock_drift(tracks: Tracks, clock_drift_file: str, inplace: bool=Tru
         return tracks
     else:
         track_copy = tracks.copy()
-        track_copy["point_dt"] = correct_clock_drift
+        track_copy["point_dt"] = correct_point_dt
         return track_copy

--- a/tests/utils/test_clock_drift.py
+++ b/tests/utils/test_clock_drift.py
@@ -1,0 +1,35 @@
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Point
+
+from nps_active_space.utils.clock_drift import correct_clock_drift
+
+
+def _make_tracks(times):
+    return gpd.GeoDataFrame(
+        {"point_dt": pd.to_datetime(times)},
+        geometry=[Point(0, 0) for _ in times],
+    )
+
+
+class TestCorrectClockDrift:
+
+    def test_inplace_false_returns_corrected_copy(self, tmp_path):
+        # drift is 10s at 00:00 and 20s at 01:00, so a point at 00:30 should
+        # pick up the interpolated 15s.
+        drift_file = tmp_path / "drift.csv"
+        drift_file.write_text(
+            "Time,Seconds\n"
+            "2020-01-01 00:00:00,10\n"
+            "2020-01-01 01:00:00,20\n"
+        )
+
+        tracks = _make_tracks(["2020-01-01 00:00:00", "2020-01-01 00:30:00"])
+        original = tracks["point_dt"].tolist()
+
+        result = correct_clock_drift(tracks, str(drift_file), inplace=False)
+
+        expected = pd.to_datetime(["2020-01-01 00:00:10", "2020-01-01 00:30:15"])
+        assert result["point_dt"].tolist() == list(expected)
+        # inplace=False shouldn't touch the caller's frame
+        assert tracks["point_dt"].tolist() == original


### PR DESCRIPTION
Ran into this reading through `clock_drift.py`. In `correct_clock_drift`, the `inplace=False` branch does:

```python
track_copy["point_dt"] = correct_clock_drift
```

so it assigns the function object instead of `correct_point_dt`, the corrected Series that the `inplace=True` branch a few lines up uses. The returned copy comes back with its whole `point_dt` column set to the function (object dtype) rather than the drift-corrected datetimes.

The default is `inplace=True`, so normal runs never hit this, which is probably why it went unnoticed.

Fix is the one-line change to assign `correct_point_dt`. I also added a small test in `tests/utils/test_clock_drift.py` that runs a point through a two-entry drift file and checks the copy comes back with the right interpolated times, and that the original frame is left alone. It fails before the change (column comes back as the function) and passes after.
