### PR TITLE
Fix ground truthing CRS regression and extract nps_active_space/setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ host = Database host.
 site_metadata = Absolute path to the the file containing site metadata. Value required for all run_ground_truthing.py and generate_active_space.py
 nvspl_archive = Absolute path to the directory where all NVSPL sound data is stored. Value required for all run_ground_truthing.py and generate_active_space.py
 adsb = Absolute path to the directory where ADSB track data is stored.  Value required if pulling ADSB tracks in run_ground_truthing.py or run_audible_transits.py
-dem = Absolute path to the DEM tif file to use for active space generation. Value required for generate_active_space.py and generate_active_space_mesh.py
+dem = Absolute path to the source DEM GeoTIFF for project_setup and active space generation. Required for project_setup.py, generate_active_space.py, and generate_active_space_mesh.py
+dem_elevation_units = Vertical units of the source DEM raster: ``feet`` or ``meters``. Defaults to ``feet``. Used by project_setup.py when clipping/reprojecting elevation to a site location.
 mennitt = Absolute path to the mennitt ambience tif. Value required for generate_active_space.py and generate_active_space_mesh.py
 
 [project]

--- a/nps_active_space/active_space/active_space_generator.py
+++ b/nps_active_space/active_space/active_space_generator.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 from warnings import warn
 
 from nps_active_space import ACTIVE_SPACE_DIR
-from nps_active_space.setup.site import create_site_dir, write_listener_site_file
+from nps_active_space.setup.site_writer import create_site_dir, write_listener_site_file
 from nps_active_space.utils.models import Microphone
 from nps_active_space.utils.computation import (
     build_src_point_mesh,

--- a/nps_active_space/active_space/active_space_generator.py
+++ b/nps_active_space/active_space/active_space_generator.py
@@ -21,6 +21,7 @@ from tqdm import tqdm
 from warnings import warn
 
 from nps_active_space import ACTIVE_SPACE_DIR
+from nps_active_space.setup.site import create_site_dir, write_listener_site_file
 from nps_active_space.utils.models import Microphone
 from nps_active_space.utils.computation import (
     build_src_point_mesh,
@@ -87,29 +88,7 @@ class ActiveSpaceGenerator:
         self._flt_file = None
         self._site_file = None
 
-        self._make_dir_tree()
-
-    def _make_dir_tree(self):
-        """Create a canonical NMSIM project directory. Copied from NMSIM_Create_Base_Layers.py"""
-        directories = [
-            "Input_Data",
-            "Input_Data/01_ELEVATION",
-            "Input_Data/02_IMPEDANCE",
-            "Input_Data/03_TRAJECTORY",
-            "Input_Data/04_LAYERS",
-            "Input_Data/05_SITES",
-            "Input_Data/06_AMBIENCE",
-            "Input_Data/07_WEATHER",
-            "Input_Data/08_TREES",
-            "Output_Data",
-            "Output_Data/ASCII",
-            "Output_Data/IMAGES",
-            "Output_Data/SITE",
-            "Output_Data/TIG_TIS"
-        ]
-        for directory in directories:
-            if not os.path.exists(f"{self.root_dir}/{directory}"):
-                os.makedirs(f"{self.root_dir}/{directory}")
+        create_site_dir(self.root_dir)
 
     def _mask_dem_file(self, dem_src: str, study_area: gpd.GeoDataFrame, project: bool = False,
                        buffer: Optional[int] = None, suffix: str = '') -> str:
@@ -299,14 +278,9 @@ class ActiveSpaceGenerator:
         -------
         The name of the site file.
         """
-        site_filename = f"{self.root_dir}/Input_Data/05_SITES/{mic.name}.sit"
-        with open(site_filename, 'w') as site_file:
-            site_file.write("    0\n")
-            site_file.write("    1\n")
-            site_file.write("{0:19.0f}.{1:9.0f}.{2:10.5f} {3:20}\n".format(mic.x, mic.y, mic.z, mic.name))
-            site_file.write(f"{dem_file}\n")
-
-        return site_filename
+        return str(write_listener_site_file(
+            self.root_dir, mic.name, mic.x, mic.y, mic.z, dem_file
+        ))
 
     def _create_instruction_files(self, flt_file: str, site_file: str, trajectory_file: str,
                                   omni_source_file: str) -> str:

--- a/nps_active_space/config/DENA_example.config
+++ b/nps_active_space/config/DENA_example.config
@@ -15,6 +15,7 @@ nvspl_archive = example_data/nvspl_archive
 adsb = example_data/ADS-B/healy_repeater
 ais =
 dem =
+dem_elevation_units = feet
 mennitt =
 
 [project]

--- a/nps_active_space/config/GLBA_example.config
+++ b/nps_active_space/config/GLBA_example.config
@@ -15,6 +15,7 @@ nvspl_archive = example_data/nvspl_archive
 adsb =
 ais = example_data/MXAK-AIS-GLBA
 dem =
+dem_elevation_units = feet
 mennitt =
 
 [project]

--- a/nps_active_space/config/template.config
+++ b/nps_active_space/config/template.config
@@ -11,6 +11,7 @@ nvspl_archive =
 adsb =
 ais =
 dem =
+dem_elevation_units = feet
 mennitt =
 
 [project]

--- a/nps_active_space/scripts/README.md
+++ b/nps_active_space/scripts/README.md
@@ -5,6 +5,7 @@ The `nps_active_space` [toolkit architecture](https://github.com/dbetchkal/NPS-A
 This directory contains the scripts along with instruction for their use via a command line interface. See [below](#use-cases) for the most common use cases, and [further below](#script-usage) for detailed documentation of each script.
 
 - [project_setup.py](#project-setup)
+- [migrate_project_sites.py](#migrate-project-sites)
 - [run_ground_truthing.py](#run-ground-truthing)
 - [plot_altitudes.py](#plot-altitudes)
 - [generate_3d_active_space.py](#generate-3d-active-space)
@@ -205,6 +206,29 @@ Example executions:
 
 ```bash
 $ python -u -W ignore nps_active_space/scripts/project_setup.py -e production -u DENA -s CNTW -y 2021 --mic-coord -148.98987 63.39493 --studyarea-sw  -149.060585 63.345825 --studyarea-ne  -148.770107 63.462577
+```
+
+### Migrate Project Sites
+
+Rewrites legacy `.sit` microphone coordinates to the NMSIM project UTM zone (western study-area edge). Use this when on-disk deployments were created before the project-zone `.sit` fix. Updates only the `.sit` file; it does not re-clip elevation data.
+
+| command-line arg        | description                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `-e`, `--environment`   | **required.**<br/>The configuration environment to use. _Ex_: To use `production.config` pass `-e production`                                    |
+| `--all`                 | Migrate every deployment found under the configured project directory. Mutually exclusive with `-u`/`-s`/`-y`.                                   |
+| `-u`, `--unit`          | Four letter NPS unit code. Required with `-s` and `-y` when not using `--all`.                                                                     |
+| `-s`, `--site`          | Four letter site code. Required with `-u` and `-y` when not using `--all`.                                                                       |
+| `-y`, `--year`          | Deployment year, YYYY. Required with `-u` and `-s` when not using `--all`.                                                                         |
+| `--dry-run`             | Report legacy `.sit` files without writing changes.                                                                                              |
+
+Example executions:
+
+```bash
+$ python -m nps_active_space.scripts.migrate_project_sites -e DENA -u DENA -s BULL -y 2019
+```
+
+```bash
+$ python -m nps_active_space.scripts.migrate_project_sites -e DENA --all --dry-run
 ```
 
 ### Run Ground Truthing

--- a/nps_active_space/scripts/migrate_project_sites.py
+++ b/nps_active_space/scripts/migrate_project_sites.py
@@ -1,0 +1,98 @@
+"""
+Rewrite legacy ``.sit`` microphone coordinates to the NMSIM project UTM zone.
+
+Use this after upgrading to the project-zone ``.sit`` writer fix when on-disk deployments
+were created with mic-local UTM easting/northing. This updates only the ``.sit`` file; it
+does not re-clip elevation data or require ``data.dem`` in the config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import nps_active_space.utils.config as cfg
+from nps_active_space.setup.site_migrate import (
+    SitMigrationResult,
+    migrate_deployment_sit,
+    migrate_project_sites,
+)
+
+
+def _print_result(result: SitMigrationResult) -> None:
+    label = f"{result.unit} {result.site} {result.year}"
+    match result.action:
+        case "skipped_ok":
+            print(f"ok       {label}  already project zone ({result.project_utm})")
+        case "migrated":
+            print(
+                f"migrate  {label}  {result.decoded_utm} -> {result.project_utm}  "
+                f"{result.sit_path}"
+            )
+        case "dry_run_would_migrate":
+            print(
+                f"dry-run  {label}  would migrate {result.decoded_utm} -> "
+                f"{result.project_utm}"
+            )
+        case "failed":
+            print(f"failed   {label}  {result.message or result.sit_path}")
+
+
+def _summarize(results: list[SitMigrationResult]) -> int:
+    migrated = sum(result.action == "migrated" for result in results)
+    ok = sum(result.action == "skipped_ok" for result in results)
+    dry_run = sum(result.action == "dry_run_would_migrate" for result in results)
+    failed = sum(result.action == "failed" for result in results)
+    print("---")
+    print(f"Summary: {migrated} migrated, {ok} ok, {dry_run} dry-run, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Rewrite legacy .sit files to use the NMSIM project UTM zone."
+    )
+    parser.add_argument(
+        "-e",
+        "--environment",
+        required=True,
+        help="The configuration environment to run the script in.",
+    )
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--all", action="store_true", help="Migrate every deployment found.")
+    target.add_argument("-u", "--unit", help="Four letter unit code. E.g. DENA")
+    parser.add_argument("-s", "--site", help="Four letter site code. E.g. BULL")
+    parser.add_argument("-y", "--year", type=int, help="Four digit year. E.g. 2019")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report legacy .sit files without writing changes.",
+    )
+    args = parser.parse_args()
+
+    if args.unit and not (args.site and args.year):
+        parser.error("-u requires -s and -y")
+    if (args.site or args.year) and not args.unit:
+        parser.error("-s and -y require -u")
+
+    cfg.initialize(environment=args.environment)
+    project_dir = Path(cfg.read("project", "dir"))
+
+    if args.all:
+        results = migrate_project_sites(project_dir, dry_run=args.dry_run)
+    else:
+        results = [
+            migrate_deployment_sit(
+                project_dir,
+                args.unit,
+                args.site,
+                args.year,
+                dry_run=args.dry_run,
+            )
+        ]
+
+    for result in results:
+        _print_result(result)
+
+    sys.exit(_summarize(results))

--- a/nps_active_space/scripts/project_setup.py
+++ b/nps_active_space/scripts/project_setup.py
@@ -1,359 +1,74 @@
-from affine import Affine
-import argparse
-import geopandas as gpd
-import glob
-import numpy as np
-from pathlib import Path
-import rasterio
-from rasterio.mask import mask as rio_mask
-from rasterio.warp import calculate_default_transform, reproject, Resampling
-from shapely.geometry import box, mapping, Point
-import nps_active_space.utils.config as cfg
-from nps_active_space.utils.computation import coords_to_utm
-
 """
-This script creates the overarching NMSIM project that is used by every module of `NPS-ActiveSpace`.
+This script creates the overarching NMSIM project that is used by every module of ``NPS-ActiveSpace``.
 This requires two conceptual inputs: (1) a study area polygon, and (2) a listening location point.
 We use the study area to prepare a portion of a Digital Elevation Model for use in computation and visualization.
-The elevation data is also converted to an antiquated ESRI GridFloat format required by `NMSIM`.
+The elevation data is also converted to an antiquated ESRI GridFloat format required by ``NMSIM``.
 We represent the listening location coordinates as a canonical NMSIM site (.sit) file.
+
+Library functions live in :mod:`nps_active_space.setup`.
 """
 
-__all__ = [
-    'create_NMSIM_site_dir',
-    'create_NMSIM_site_file',
-    'create_study_area',
-    'create_NMSIM_elevation_tif',
-    'create_gridfloat'
-]
+import argparse
+from pathlib import Path
 
-def create_NMSIM_site_dir(siteDir):
-    """
-    Create a canonical NMSIM site directory structure expected by downstream NPS-ActiveSpace modules.
-
-    Inputs
-    ------
-    siteDir (str | pathlib.Path): base directory where the canonical site structure will be created
-
-    Returns
-    -------
-    None
-    """
-    subfolders = [
-            "Input_Data",
-            "Input_Data/01_ELEVATION",
-            "Input_Data/02_IMPEDANCE",
-            "Input_Data/03_TRAJECTORY",
-            "Input_Data/04_LAYERS",
-            "Input_Data/05_SITES",
-            "Input_Data/06_AMBIENCE",
-            "Input_Data/07_WEATHER",
-            "Input_Data/08_TREES",
-            "Output_Data",
-            "Output_Data/ASCII",
-            "Output_Data/IMAGES",
-            "Output_Data/SITE",
-            "Output_Data/TIG_TIS",
-    ]
-
-    siteDir = Path(siteDir)
-    for folderExt in subfolders:
-        Path(siteDir / folderExt).mkdir(parents=True, exist_ok=True)
-
-
-def create_NMSIM_site_file(site_dir, unit, site, year, long_utm, lat_utm, height=1.5):
-
-    """
-    Create an NMSIM site (.sit) file for a given NPS microphone deployment.
-    The .sit file represents a "listener location" (microphone location), one of two conceptual inputs to NPS-ActiveSpace.
-    
-    Inputs
-    ------
-    site_dir (str): a path location of a canonical NMSIM site directory
-    unit (str): 4-character NPS Alpha Code, e.g. "BITH", "YUCH"
-    site (str): alpha-numeric acoustic monitoring site code, e.g., "002", "TRLA"
-    year (int): four digit deployment year, e.g. 2018
-    long_utm (float): listening location longitude in meters (microphone's UTM zone)
-    lat_utm (float): listening location latitude in meters (microphone's UTM zone)
-    height (float): microphone height in meters; defaults to ANSI standard, 1.5 meters
-    
-    Returns
-    -------
-    None
-    """
-    
-    out_path = Path(site_dir) / "Input_Data" / "05_SITES" / (unit + site + str(year) + ".sit") # deployment location can subtly vary by year
-    elev_dir = Path(site_dir) / "Input_Data" / "01_ELEVATION"
-    matches = list(elev_dir.glob("*.flt"))
-    if not matches:
-        raise FileNotFoundError(f"No .flt files found in {elev_dir}")
-
-    # open a file and write to it
-    with open(out_path, 'w') as site_file:
-
-        site_file.write("    0\n")
-        site_file.write("    1\n")
-        site_file.write("{0:19.0f}.{1:9.0f}.{2:10.5f} {3:20}\n".format(long_utm, lat_utm, height, unit+site))
-        site_file.write(str(next(elev_dir.glob("*.flt")))+"\n")
-
-
-def create_study_area(site_dir, unit, site, year, study_area_sw_corner, study_area_ne_corner) -> gpd.GeoDataFrame:
-    """
-    Create the most important conceptual input of `NPS-ActiveSpace`: a user-defined study area.
-    
-    Builds a rectangular polygon from the provided SW/NE corners and saves it as an ESRI shapefile (.shp).
-
-    Inputs
-    ------
-    site_dir (str|Path): a canonical NMSIM project directory
-    unit (str): 4-character NPS Alpha Code, e.g. "BITH", "YUCH"
-    site (str): alpha-numeric acoustic monitoring site code, e.g., "002", "TRLA"
-    year (int): four digit deployment year, e.g. 2018
-    study_area_sw_corner (tuple): study area SW corner x y (WGS84). Example: (-136.088360, 58.569310)
-    study_area_ne_corner (tuple): study area NE corner x y (WGS84). Example: (-135.818994, 58.706095)
-
-    Returns
-    -------
-    study_area_wgs84 (gpd.GeoDataFrame): the rectangular study area geometry (WGS84),
-                                          with columns ["Unit", "Site", "Year"]
-    """
-    # Input args are WGS84 lon/lat; shapely box expects x1,y1,x2,y2 => lon/lat
-    study_area_wgs84 = gpd.GeoDataFrame([[unit, site, year]],
-                                        geometry=[box(*study_area_sw_corner, *study_area_ne_corner)],
-                                        crs="EPSG:4326",
-                                        columns=["Unit", "Site", "Year"])
-    study_area_path = Path(site_dir) / (f"{unit}{site}_study_area.shp")
-    study_area_proj = study_area_wgs84.to_crs("EPSG:4269")
-    study_area_proj.to_file(study_area_path)
-    return study_area_wgs84
-
-
-def create_NMSIM_elevation_tif(source_dem, study_area_wgs84, dst_crs, output_tif, feet_to_meters, nodata_int16) -> tuple[np.ndarray, Affine, int, int]:
-    """
-    Clip a source DEM to the study area, reproject, and convert to int16 elevation suitable for `NMSIM`.
-    Saves a .tif that is used downstream for computation and visualization tasks.
-
-    Inputs
-    ------
-    source_dem (str | pathlib.Path): path to the input DEM raster
-    study_area_wgs84 (gpd.GeoDataFrame): study area polygon (WGS84)
-    dst_crs (str): coordinate reference system for the destination raster
-    output_tif (str | pathlib.Path): path for output GeoTIFF file
-    feet_to_meters (float): scalar constant converting feet to meters
-    nodata_int16 (np.int16): the int16 value used as NODATA in the output GeoTIFF
-
-    Returns
-    -------
-    dst_int16 (np.ndarray): a 2D array (dtype int16) of clipped/reprojected elevations
-    dst_transform (affine.Affine): the affine transformation matrix representing reprojection from WGS84 to NAD83 GCS North American
-    dst_width (int): number of columns in the output raster
-    dst_height (int): number of rows in the output raster
-
-    Notes
-    -----
-    [1] We assume the source DEM is in feet.
-    [2] `NMSIM` requires a 16-bit signed integer GeoTIFF.
-    """
-    # Clip using source DEM CRS
-    with rasterio.open(source_dem) as src:
-        study_in_src = study_area_wgs84.to_crs(src.crs)
-        clipped, clipped_transform = rio_mask(
-            src,
-            [mapping(g) for g in study_in_src.geometry],
-            crop=True,
-            filled=False,
-        )
-        clipped = clipped[0]
-        src_profile = src.profile
-        src_crs = src.crs
-
-    # Compute output grid geometry
-    left = clipped_transform.c
-    top = clipped_transform.f
-    right = left + clipped.shape[1] * clipped_transform.a
-    bottom = top + clipped.shape[0] * clipped_transform.e
-
-    dst_transform, dst_width, dst_height = calculate_default_transform(
-        src_crs,
-        dst_crs,
-        clipped.shape[1],
-        clipped.shape[0],
-        left,
-        bottom,
-        right,
-        top,
-    )
-
-    # Reproject + unit conversion (assumes input raster in FEET)
-    dst = np.full((dst_height, dst_width), nodata_int16, dtype=np.float32)
-
-    reproject(
-        source=clipped.filled(src_profile["nodata"]),
-        destination=dst,
-        src_transform=clipped_transform,
-        src_crs=src_crs,
-        src_nodata=src_profile["nodata"],
-        dst_transform=dst_transform,
-        dst_crs=dst_crs,
-        dst_nodata=np.float32(nodata_int16),
-        resampling=Resampling.bilinear,
-    )
-
-    nodata_mask = dst == nodata_int16
-    dst[~nodata_mask] = np.rint(dst[~nodata_mask] * feet_to_meters)
-    dst_int16 = dst.astype(np.int16)
-
-    profile = dict(
-        driver="GTiff",
-        dtype=rasterio.int16,
-        count=1,
-        compress="lzw",
-        width=dst_width,
-        height=dst_height,
-        transform=dst_transform,
-        crs=dst_crs,
-        nodata=nodata_int16,
-    )
-
-    Path(output_tif).parent.mkdir(parents=True, exist_ok=True)
-    with rasterio.open(output_tif, "w", **profile) as ds:
-        ds.write(dst_int16, 1)
-
-    return dst_int16, dst_transform, dst_width, dst_height
-
-
-def create_gridfloat(output_base, dst_int16, dst_transform, dst_width,
-                     dst_height, nodata_int16, gridfloat_nodata):
-    """
-    Write elevation raster data into legacy ESRI GridFloat format (.flt + .hdr).
-
-    `NMSIM` uses a legacy ESRI GridFloat for elevation/impedance inputs, which has two associated files:
-        - .flt: binary grid values (float32)
-        - .hdr ASCII header containing grid geometry and NODATA metadata
-
-    
-    Inputs
-    ------
-    output_base (str | pathlib.Path): output path without extension; writes {output_base}.flt, {output_base}.hdr
-    dst_int16 (np.ndarray): 2D array of elevations in int16
-    dst_transform (affine.Affine): the affine transformation matrix representing reprojection from WGS84 to NAD83 GCS North American
-    dst_width (int): number of columns in the raster
-    dst_height (int): number of rows in the raster
-    nodata_int16 (np.int16): the int16 value used as NODATA in `dst_int16`
-    gridfloat_nodata (np.float32): the float32 NODATA value to store in the .flt grid
-    
-    Returns
-    -------
-    None
-
-    Notes
-    -----
-    [1] For more information on ESRI GridFloat format, see https://www.loc.gov/preservation/digital/formats/fdd/fdd000422.shtml
-    [2] Header fields use transform geometry: xllcorner, yllcorner, and cellsize.
-    """
-
-    # first we'll write the grid, .flt
-    grid = dst_int16.astype(np.float32)
-
-    grid[dst_int16 == nodata_int16] = gridfloat_nodata
-
-    grid.tofile(output_base.with_suffix(".flt"))
-
-    # then we'll write the header, .hdr
-    transform = dst_transform
-
-    xllcorner = transform.c
-
-    yllcorner = transform.f + dst_height * transform.e
-
-    cellsize = transform.a
-
-    with open(output_base.with_suffix(".hdr"), "w") as hdr:
-
-        hdr.write(f"ncols         {dst_width}\n")
-        hdr.write(f"nrows         {dst_height}\n")
-        hdr.write(f"xllcorner     {xllcorner:.15f}\n")
-        hdr.write(f"yllcorner     {yllcorner:.15f}\n")
-        hdr.write(f"cellsize      {cellsize:.15f}\n")
-        hdr.write(f"NODATA_value  {gridfloat_nodata:.0f}\n")
-        hdr.write("byteorder     LSBFIRST\n")
-
+import nps_active_space.utils.config as cfg
+from nps_active_space.setup import NMSIM_DST_CRS, setup_site
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-e', '--environment', required=True,
-                          help="The configuration environment to run the script in.")
-    parser.add_argument('-u', '--unit', required=True,
-                          help="Four letter unit code. E.g. DENA")
-    parser.add_argument('-s', '--site', required=True,
-                          help="Four letter site code. E.g. TRLA")
-    parser.add_argument('-y', '--year', type=int, required=True,
-                          help="Four digit year. E.g. 2018")
-    parser.add_argument('--mic-coord', nargs=2, type=float, required=True,
-                        help="Mic coordinates x y (WGS84). Example: -136.088360 58.569310")
-    parser.add_argument('--studyarea-sw', nargs=2, type=float, required=True,
-                        help="Study area SW corner x y (WGS84). Example: -136.088360 58.569310")
-    parser.add_argument('--studyarea-ne', nargs=2, type=float, required=True,
-                        help="Study area NE corner x y (WGS84). Example: -135.818994 58.706095")
+    parser.add_argument(
+        "-e",
+        "--environment",
+        required=True,
+        help="The configuration environment to run the script in.",
+    )
+    parser.add_argument("-u", "--unit", required=True, help="Four letter unit code. E.g. DENA")
+    parser.add_argument("-s", "--site", required=True, help="Four letter site code. E.g. TRLA")
+    parser.add_argument("-y", "--year", type=int, required=True, help="Four digit year. E.g. 2018")
+    parser.add_argument(
+        "--mic-coord",
+        nargs=2,
+        type=float,
+        required=True,
+        help="Mic coordinates x y (WGS84). Example: -136.088360 58.569310",
+    )
+    parser.add_argument(
+        "--studyarea-sw",
+        nargs=2,
+        type=float,
+        required=True,
+        help="Study area SW corner x y (WGS84). Example: -136.088360 58.569310",
+    )
+    parser.add_argument(
+        "--studyarea-ne",
+        nargs=2,
+        type=float,
+        required=True,
+        help="Study area NE corner x y (WGS84). Example: -135.818994 58.706095",
+    )
     args = parser.parse_args()
 
-    feet_to_meters = 0.3048
-    nodata_int16 = np.int16(32767)
-    gridfloat_nodata = np.float32(-32768.0)
-    dst_crs = "EPSG:4269"
-
     cfg.initialize(environment=args.environment)
-    project_dir = Path(cfg.read('project', 'dir'))
-    site_dir = Path(cfg.read('project', 'dir')) / f"{args.unit}{args.site}"
+    project_dir = Path(cfg.read("project", "dir"))
+    site_dir = project_dir / f"{args.unit}{args.site}"
 
-    create_NMSIM_site_dir(site_dir) # a standardized template directory structure for `NMSIM` projects
+    result = setup_site(
+        site_dir=site_dir,
+        unit=args.unit,
+        site=args.site,
+        year=args.year,
+        mic_coord=tuple(args.mic_coord),
+        studyarea_sw=tuple(args.studyarea_sw),
+        studyarea_ne=tuple(args.studyarea_ne),
+        source_dem=cfg.read("data", "dem"),
+        dst_crs=NMSIM_DST_CRS,
+        source_elevation_units=cfg.read_dem_elevation_units(),
+    )
+
     print(f"Created a new NMSIM site directory {args.unit}{args.site} in {project_dir}.")
-
-    study_area_wgs84 = create_study_area(site_dir=site_dir,
-                                         unit=args.unit,
-                                         site=args.site,
-                                         year=args.year,
-                                         study_area_sw_corner=args.studyarea_sw,
-                                         study_area_ne_corner=args.studyarea_ne)
-    study_area_path = site_dir / f"{args.unit}{args.site}_study_area.shp"
-    print(f"Saved study area to {study_area_path}")
-
-    # to create a .sit file, we will eventually need the UTM coordinates of the microphone...
-    utm_epsg, _ = coords_to_utm(lat=args.mic_coord[1], lon=args.mic_coord[0]) 
-    mic_utm = gpd.GeoSeries([Point(args.mic_coord)], crs="EPSG:4326").to_crs(utm_epsg)
-
-    source_dem = cfg.read('data', 'dem')
-    # quirk: `NMSIM` expects the elevation input's spatial reference to be the UTM Zone of the westernmost exent
-    #         this is occasionally different than the microphone's UTM Zone in the .sit file
-    _, utm_zone_str = coords_to_utm(lat=args.studyarea_sw[1], lon=args.studyarea_sw[0]) 
-
-    output_base = site_dir / "Input_Data" / "01_ELEVATION" / f"elevation_m_nad83_utm{utm_zone_str}"
-    output_tif = output_base.with_suffix(".tif")
-
-    dst_int16, dst_transform, dst_width, dst_height = create_NMSIM_elevation_tif(source_dem=source_dem,
-                                                                                 study_area_wgs84=study_area_wgs84,
-                                                                                 dst_crs=dst_crs,
-                                                                                 output_tif=output_tif,
-                                                                                 feet_to_meters=feet_to_meters,
-                                                                                 nodata_int16=nodata_int16)
-    print(f"Elevation data have been written to {output_tif}.")
-    # TODO when a National Landcover Database (NLCD) mapping has been construed, an equivalent `create_NMSIM_landcover_tif` function would belong here...
-    
-    create_gridfloat(output_base=output_base,
-                     dst_int16=dst_int16,
-                     dst_transform=dst_transform,
-                     dst_width=dst_width,
-                     dst_height=dst_height,
-                     nodata_int16=nodata_int16,
-                     gridfloat_nodata=gridfloat_nodata)
+    print(f"Saved study area to {result.study_area_path}")
+    print(f"Elevation data have been written to {result.elevation_tif_path}.")
     print("Grid float elevation file components (.flt, .hdr) have been written.")
-
-    create_NMSIM_site_file(site_dir,
-                           unit=args.unit,
-                           site=args.site,
-                           year=args.year,
-                           long_utm=float(mic_utm.x.iloc[0]),
-                           lat_utm=float(mic_utm.y.iloc[0]),
-                           height=1.5)
     print("NMSIM site file has been written. Finished!")
+

--- a/nps_active_space/scripts/run_ground_truthing.py
+++ b/nps_active_space/scripts/run_ground_truthing.py
@@ -12,7 +12,6 @@ from nps_active_space.utils.helpers import (
     load_DEM,
     load_studyarea,
 )
-from nps_active_space.utils.computation import coords_to_utm
 from nps_active_space.utils.clock_drift import correct_clock_drift
 
 
@@ -100,7 +99,7 @@ if __name__ == '__main__':
         tracks=tracks,
         nvspl=nvspl,
         mic=microphone,
-        crs=coords_to_utm(microphone.lat, microphone.lon),
+        crs=microphone.crs,
         study_area=study_area,
         track_source=args.track_source,
         dem=dem,

--- a/nps_active_space/setup/__init__.py
+++ b/nps_active_space/setup/__init__.py
@@ -1,48 +1,6 @@
 """NMSIM project setup: study area, elevation, site artifacts, and workflow orchestration."""
 
-from nps_active_space.setup.elevation import (
-    FEET_TO_METERS,
-    GRIDFLOAT_NODATA,
-    NMSIM_DST_CRS,
-    NODATA_INT16,
-    create_elevation_tif,
-    parse_source_elevation_units,
-    write_gridfloat,
-)
-from nps_active_space.setup.site_decoder import parse_sit_coords_line
-from nps_active_space.setup.site_writer import (
-    NMSIM_SITE_SUBFOLDERS,
-    NMSIM_SITES_DIR,
-    create_site_dir,
-    create_site_file,
-    create_study_area,
-    deployment_sit_name,
-    sit_file_path,
-    write_listener_site_file,
-    write_site_file,
-)
-from nps_active_space.setup.workflow import SetupSiteResult, setup_site
-from nps_active_space.utils.enums import SourceElevationUnits
+from nps_active_space.setup.elevation import NMSIM_DST_CRS
+from nps_active_space.setup.workflow import setup_site
 
-__all__ = [
-    "FEET_TO_METERS",
-    "GRIDFLOAT_NODATA",
-    "NMSIM_DST_CRS",
-    "NMSIM_SITE_SUBFOLDERS",
-    "NMSIM_SITES_DIR",
-    "NODATA_INT16",
-    "SourceElevationUnits",
-    "SetupSiteResult",
-    "create_elevation_tif",
-    "create_site_dir",
-    "create_site_file",
-    "create_study_area",
-    "deployment_sit_name",
-    "parse_sit_coords_line",
-    "parse_source_elevation_units",
-    "setup_site",
-    "sit_file_path",
-    "write_gridfloat",
-    "write_listener_site_file",
-    "write_site_file",
-]
+__all__ = ["NMSIM_DST_CRS", "setup_site"]

--- a/nps_active_space/setup/__init__.py
+++ b/nps_active_space/setup/__init__.py
@@ -9,14 +9,14 @@ from nps_active_space.setup.elevation import (
     parse_source_elevation_units,
     write_gridfloat,
 )
-from nps_active_space.setup.site import (
+from nps_active_space.setup.site_decoder import parse_sit_coords_line
+from nps_active_space.setup.site_writer import (
     NMSIM_SITE_SUBFOLDERS,
     NMSIM_SITES_DIR,
     create_site_dir,
     create_site_file,
     create_study_area,
     deployment_sit_name,
-    parse_sit_coords_line,
     sit_file_path,
     write_listener_site_file,
     write_site_file,

--- a/nps_active_space/setup/__init__.py
+++ b/nps_active_space/setup/__init__.py
@@ -1,0 +1,58 @@
+"""NMSIM project setup: study area, elevation, site artifacts, and workflow orchestration."""
+
+from nps_active_space.setup.elevation import (
+    FEET_TO_METERS,
+    GRIDFLOAT_NODATA,
+    NMSIM_DST_CRS,
+    NODATA_INT16,
+    create_elevation_tif,
+    parse_source_elevation_units,
+    write_gridfloat,
+)
+from nps_active_space.setup.site import (
+    NMSIM_SITE_SUBFOLDERS,
+    NMSIM_SITES_DIR,
+    create_site_dir,
+    create_site_file,
+    create_study_area,
+    deployment_sit_name,
+    parse_sit_coords_line,
+    sit_file_path,
+    write_listener_site_file,
+    write_site_file,
+)
+from nps_active_space.setup.workflow import SetupSiteResult, setup_site
+from nps_active_space.utils.enums import SourceElevationUnits
+
+# Backward-compatible aliases for project_setup.py function names (PR #75).
+create_NMSIM_site_dir = create_site_dir
+create_NMSIM_site_file = create_site_file
+create_NMSIM_elevation_tif = create_elevation_tif
+create_gridfloat = write_gridfloat
+
+__all__ = [
+    "FEET_TO_METERS",
+    "GRIDFLOAT_NODATA",
+    "NMSIM_DST_CRS",
+    "NMSIM_SITE_SUBFOLDERS",
+    "NMSIM_SITES_DIR",
+    "NODATA_INT16",
+    "SourceElevationUnits",
+    "SetupSiteResult",
+    "create_NMSIM_elevation_tif",
+    "create_NMSIM_site_dir",
+    "create_NMSIM_site_file",
+    "create_elevation_tif",
+    "create_gridfloat",
+    "create_site_dir",
+    "create_site_file",
+    "create_study_area",
+    "deployment_sit_name",
+    "parse_sit_coords_line",
+    "parse_source_elevation_units",
+    "setup_site",
+    "sit_file_path",
+    "write_gridfloat",
+    "write_listener_site_file",
+    "write_site_file",
+]

--- a/nps_active_space/setup/__init__.py
+++ b/nps_active_space/setup/__init__.py
@@ -24,12 +24,6 @@ from nps_active_space.setup.site_writer import (
 from nps_active_space.setup.workflow import SetupSiteResult, setup_site
 from nps_active_space.utils.enums import SourceElevationUnits
 
-# Backward-compatible aliases for project_setup.py function names (PR #75).
-create_NMSIM_site_dir = create_site_dir
-create_NMSIM_site_file = create_site_file
-create_NMSIM_elevation_tif = create_elevation_tif
-create_gridfloat = write_gridfloat
-
 __all__ = [
     "FEET_TO_METERS",
     "GRIDFLOAT_NODATA",
@@ -39,11 +33,7 @@ __all__ = [
     "NODATA_INT16",
     "SourceElevationUnits",
     "SetupSiteResult",
-    "create_NMSIM_elevation_tif",
-    "create_NMSIM_site_dir",
-    "create_NMSIM_site_file",
     "create_elevation_tif",
-    "create_gridfloat",
     "create_site_dir",
     "create_site_file",
     "create_study_area",

--- a/nps_active_space/setup/elevation.py
+++ b/nps_active_space/setup/elevation.py
@@ -1,0 +1,211 @@
+"""DEM clip/reproject and ESRI GridFloat output for NMSIM."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import rasterio
+from affine import Affine
+from rasterio.mask import mask as rio_mask
+from rasterio.warp import Resampling, calculate_default_transform, reproject
+from shapely.geometry import mapping
+
+from nps_active_space.utils.enums import FEET_TO_METERS, SourceElevationUnits
+
+NODATA_INT16 = np.int16(32767)
+GRIDFLOAT_NODATA = np.float32(-32768.0)
+NMSIM_DST_CRS = "EPSG:4269"  # NAD 83 - https://epsg.io/4269
+
+
+def parse_source_elevation_units(units: str) -> SourceElevationUnits:
+    """Validate and normalize a ``dem_elevation_units`` config value."""
+    return SourceElevationUnits.parse_config_value(units)
+
+
+def _to_meters_elevation(values: np.ndarray, source_units: SourceElevationUnits) -> np.ndarray:
+    """Convert raster elevation values from ``source_units`` to integer meters."""
+    return np.rint(values * source_units.to_meters_scale())
+
+
+def create_elevation_tif(
+    source_dem: str | Path,
+    study_area_wgs84: gpd.GeoDataFrame,
+    dst_crs: str,
+    output_tif: str | Path,
+    nodata_int16: np.int16,
+    *,
+    source_elevation_units: SourceElevationUnits = SourceElevationUnits.FEET,
+) -> tuple[np.ndarray, Affine, int, int]:
+    """
+    Clip a feet- or meters-elevation source DEM, reproject, and write int16 meters for ``NMSIM``.
+
+    Reads a source raster, clips it to ``study_area_wgs84``, reprojects to ``dst_crs``,
+    converts elevation to integer meters, and saves a GeoTIFF used downstream for
+    computation and visualization.
+
+    Inputs
+    ------
+    source_dem : str | Path
+        Path to the input DEM raster. Elevation values must be in ``source_elevation_units``.
+    study_area_wgs84 : gpd.GeoDataFrame
+        Study area polygon (WGS84).
+    dst_crs : str
+        Coordinate reference system for the destination raster.
+    output_tif : str | Path
+        Path for output GeoTIFF file (elevation values in meters).
+    nodata_int16 : np.int16
+        The int16 value used as NODATA in the output GeoTIFF.
+    source_elevation_units : SourceElevationUnits, default ``FEET``
+        Vertical units of ``source_dem`` before conversion to meters. Scripts read
+        ``dem_elevation_units`` from the environment config; library callers may override.
+
+    Returns
+    -------
+    dst_int16 : np.ndarray
+        A 2D array (dtype int16) of clipped/reprojected elevations in meters.
+    dst_transform : affine.Affine
+        The affine transformation matrix representing reprojection from WGS84 to NAD83 GCS North American.
+    dst_width : int
+        Number of columns in the output raster.
+    dst_height : int
+        Number of rows in the output raster.
+
+    Notes
+    -----
+    ``NMSIM`` requires a 16-bit signed integer GeoTIFF with elevations in meters.
+    """
+    # Clip using source DEM CRS
+    with rasterio.open(source_dem) as src:
+        study_in_src = study_area_wgs84.to_crs(src.crs)
+        clipped, clipped_transform = rio_mask(
+            src,
+            [mapping(g) for g in study_in_src.geometry],
+            crop=True,
+            filled=False,
+        )
+        clipped = clipped[0]
+        src_profile = src.profile
+        src_crs = src.crs
+
+    # Compute output grid geometry
+    left = clipped_transform.c
+    top = clipped_transform.f
+    right = left + clipped.shape[1] * clipped_transform.a
+    bottom = top + clipped.shape[0] * clipped_transform.e
+
+    dst_transform, dst_width, dst_height = calculate_default_transform(
+        src_crs,
+        dst_crs,
+        clipped.shape[1],
+        clipped.shape[0],
+        left,
+        bottom,
+        right,
+        top,
+    )
+
+    dst = np.full((dst_height, dst_width), nodata_int16, dtype=np.float32)
+
+    reproject(
+        source=clipped.filled(src_profile["nodata"]),
+        destination=dst,
+        src_transform=clipped_transform,
+        src_crs=src_crs,
+        src_nodata=src_profile["nodata"],
+        dst_transform=dst_transform,
+        dst_crs=dst_crs,
+        dst_nodata=np.float32(nodata_int16),
+        resampling=Resampling.bilinear,
+    )
+
+    nodata_mask = dst == nodata_int16
+    dst[~nodata_mask] = _to_meters_elevation(dst[~nodata_mask], source_elevation_units)
+    dst_int16 = dst.astype(np.int16)
+
+    profile = dict(
+        driver="GTiff",
+        dtype=rasterio.int16,
+        count=1,
+        compress="lzw",
+        width=dst_width,
+        height=dst_height,
+        transform=dst_transform,
+        crs=dst_crs,
+        nodata=nodata_int16,
+    )
+
+    Path(output_tif).parent.mkdir(parents=True, exist_ok=True)
+    with rasterio.open(output_tif, "w", **profile) as ds:
+        ds.write(dst_int16, 1)
+
+    return dst_int16, dst_transform, dst_width, dst_height
+
+
+def write_gridfloat(
+    output_base: str | Path,
+    dst_int16: np.ndarray,
+    dst_transform: Affine,
+    dst_width: int,
+    dst_height: int,
+    nodata_int16: np.int16,
+    gridfloat_nodata: np.float32,
+) -> None:
+    """
+    Write elevation raster data into legacy ESRI GridFloat format (.flt + .hdr).
+
+    ``NMSIM`` uses a legacy ESRI GridFloat for elevation/impedance inputs, which has two associated files:
+        - .flt: binary grid values (float32)
+        - .hdr ASCII header containing grid geometry and NODATA metadata
+
+    Inputs
+    ------
+    output_base : str | Path
+        Output path without extension; writes ``{output_base}.flt``, ``{output_base}.hdr``.
+    dst_int16 : np.ndarray
+        2D array of elevations in int16.
+    dst_transform : affine.Affine
+        The affine transformation matrix representing reprojection from WGS84 to NAD83 GCS North American.
+    dst_width : int
+        Number of columns in the raster.
+    dst_height : int
+        Number of rows in the raster.
+    nodata_int16 : np.int16
+        The int16 value used as NODATA in ``dst_int16``.
+    gridfloat_nodata : np.float32
+        The float32 NODATA value to store in the .flt grid.
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    [1] For more information on ESRI GridFloat format, see https://www.loc.gov/preservation/digital/formats/fdd/fdd000422.shtml
+    [2] Header fields use transform geometry: xllcorner, yllcorner, and cellsize.
+    """
+    # first we'll write the grid, .flt
+    grid = dst_int16.astype(np.float32)
+
+    grid[dst_int16 == nodata_int16] = gridfloat_nodata
+
+    grid.tofile(Path(output_base).with_suffix(".flt"))
+
+    # then we'll write the header, .hdr
+    transform = dst_transform
+
+    xllcorner = transform.c
+
+    yllcorner = transform.f + dst_height * transform.e
+
+    cellsize = transform.a
+
+    with open(Path(output_base).with_suffix(".hdr"), "w") as hdr:
+        hdr.write(f"ncols         {dst_width}\n")
+        hdr.write(f"nrows         {dst_height}\n")
+        hdr.write(f"xllcorner     {xllcorner:.15f}\n")
+        hdr.write(f"yllcorner     {yllcorner:.15f}\n")
+        hdr.write(f"cellsize      {cellsize:.15f}\n")
+        hdr.write(f"NODATA_value  {gridfloat_nodata:.0f}\n")
+        hdr.write("byteorder     LSBFIRST\n")

--- a/nps_active_space/setup/site.py
+++ b/nps_active_space/setup/site.py
@@ -1,0 +1,206 @@
+"""NMSIM site directory, study area, and .sit file helpers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import geopandas as gpd
+from shapely.geometry import box
+
+NMSIM_SITES_DIR = "Input_Data/05_SITES"
+
+NMSIM_SITE_SUBFOLDERS = [
+    "Input_Data",
+    "Input_Data/01_ELEVATION",
+    "Input_Data/02_IMPEDANCE",
+    "Input_Data/03_TRAJECTORY",
+    "Input_Data/04_LAYERS",
+    NMSIM_SITES_DIR,
+    "Input_Data/06_AMBIENCE",
+    "Input_Data/07_WEATHER",
+    "Input_Data/08_TREES",
+    "Output_Data",
+    "Output_Data/ASCII",
+    "Output_Data/IMAGES",
+    "Output_Data/SITE",
+    "Output_Data/TIG_TIS",
+]
+
+
+def deployment_sit_name(unit: str, site: str, year: int) -> str:
+    """Return the canonical NMSIM ``.sit`` basename (without extension) for a deployment."""
+    return f"{unit}{site}{year}"
+
+
+def sit_file_path(site_dir: str | Path, sit_name: str) -> Path:
+    """Return ``{site_dir}/Input_Data/05_SITES/{sit_name}.sit``."""
+    return Path(site_dir) / NMSIM_SITES_DIR / f"{sit_name}.sit"
+
+
+def create_site_dir(site_dir: str | Path) -> None:
+    """
+    Create a canonical NMSIM site directory structure expected by downstream NPS-ActiveSpace modules.
+
+    Inputs
+    ------
+    site_dir : str | Path
+        Base directory where the canonical site structure will be created.
+
+    Returns
+    -------
+    None
+    """
+    site_path = Path(site_dir)
+    for folder in NMSIM_SITE_SUBFOLDERS:
+        (site_path / folder).mkdir(parents=True, exist_ok=True)
+
+
+def create_study_area(
+    site_dir: str | Path,
+    unit: str,
+    site: str,
+    year: int,
+    study_area_sw_corner: tuple[float, float],
+    study_area_ne_corner: tuple[float, float],
+) -> gpd.GeoDataFrame:
+    """
+    Create the most important conceptual input of ``NPS-ActiveSpace``: a user-defined study area.
+
+    Builds a rectangular polygon from the provided SW/NE corners and saves it as an ESRI shapefile (.shp).
+
+    Inputs
+    ------
+    site_dir : str | Path
+        A canonical NMSIM project directory.
+    unit : str
+        4-character NPS Alpha Code, e.g. ``BITH``, ``YUCH``.
+    site : str
+        Alpha-numeric acoustic monitoring site code, e.g., ``002``, ``TRLA``.
+    year : int
+        Four digit deployment year, e.g. 2018.
+    study_area_sw_corner : tuple
+        Study area SW corner x y (WGS84). Example: (-136.088360, 58.569310).
+    study_area_ne_corner : tuple
+        Study area NE corner x y (WGS84). Example: (-135.818994, 58.706095).
+
+    Returns
+    -------
+    study_area_wgs84 : gpd.GeoDataFrame
+        The rectangular study area geometry (WGS84), with columns ``["Unit", "Site", "Year"]``.
+    """
+    # Input args are WGS84 lon/lat; shapely box expects x1,y1,x2,y2 => lon/lat
+    study_area_wgs84 = gpd.GeoDataFrame(
+        [[unit, site, year]],
+        geometry=[box(*study_area_sw_corner, *study_area_ne_corner)],
+        crs="EPSG:4326",
+        columns=["Unit", "Site", "Year"],
+    )
+    study_area_path = Path(site_dir) / (f"{unit}{site}_study_area.shp")
+    study_area_proj = study_area_wgs84.to_crs("EPSG:4269")
+    study_area_proj.to_file(study_area_path)
+    return study_area_wgs84
+
+
+def write_site_file(
+    sit_path: str | Path,
+    easting_m: float,
+    northing_m: float,
+    height_agl_m: float,
+    label: str,
+    dem_flt_path: str | Path,
+) -> None:
+    """
+    Write the body of an NMSIM ``.sit`` listener-location file.
+
+    Low-level helper used by :func:`create_site_file` and ``ActiveSpaceGenerator``.
+    """
+    sit_path = Path(sit_path)
+    with open(sit_path, "w") as site_file:
+        site_file.write("    0\n")
+        site_file.write("    1\n")
+        site_file.write(
+            "{0:19.0f}.{1:9.0f}.{2:10.5f} {3:20}\n".format(
+                easting_m, northing_m, height_agl_m, label
+            )
+        )
+        site_file.write(str(dem_flt_path) + "\n")
+
+
+def write_listener_site_file(
+    site_dir: str | Path,
+    sit_name: str,
+    easting_m: float,
+    northing_m: float,
+    height_agl_m: float,
+    dem_flt_path: str | Path,
+    *,
+    label: str | None = None,
+) -> Path:
+    """Write ``Input_Data/05_SITES/{sit_name}.sit`` for an NMSIM listener location."""
+    sit_path = sit_file_path(site_dir, sit_name)
+    write_site_file(sit_path, easting_m, northing_m, height_agl_m, label or sit_name, dem_flt_path)
+    return sit_path
+
+
+def create_site_file(
+    site_dir: str | Path,
+    unit: str,
+    site: str,
+    year: int,
+    easting_m: float,
+    northing_m: float,
+    height: float = 1.5,
+    dem_flt_path: str | Path | None = None,
+) -> None:
+    """
+    Create an NMSIM site (.sit) file for a given NPS microphone deployment.
+    The .sit file represents a "listener location" (microphone location), one of two conceptual inputs to NPS-ActiveSpace.
+
+    Inputs
+    ------
+    site_dir : str | Path
+        A path location of a canonical NMSIM site directory.
+    unit : str
+        4-character NPS Alpha Code, e.g. ``BITH``, ``YUCH``.
+    site : str
+        Alpha-numeric acoustic monitoring site code, e.g., ``002``, ``TRLA``.
+    year : int
+        Four digit deployment year, e.g. 2018.
+    easting_m : float
+        UTM easting in meters (microphone's UTM zone).
+    northing_m : float
+        UTM northing in meters (microphone's UTM zone).
+    height : float
+        Microphone height in meters; defaults to ANSI standard, 1.5 meters.
+    dem_flt_path : str | Path, optional
+        Path to the GridFloat ``.flt`` referenced by the ``.sit`` file. When omitted,
+        the lexicographically first ``*.flt`` in ``Input_Data/01_ELEVATION`` is used.
+
+    Returns
+    -------
+    None
+    """
+    # deployment location can subtly vary by year
+    if dem_flt_path is None:
+        elev_dir = Path(site_dir) / "Input_Data" / "01_ELEVATION"
+        matches = sorted(elev_dir.glob("*.flt"))
+        if not matches:
+            raise FileNotFoundError(f"No .flt files found in {elev_dir}")
+        dem_flt_path = matches[0]
+
+    write_listener_site_file(
+        site_dir,
+        deployment_sit_name(unit, site, year),
+        easting_m,
+        northing_m,
+        height,
+        dem_flt_path,
+        label=unit + site,
+    )
+
+
+def parse_sit_coords_line(line: str) -> tuple[float, float, float]:
+    """Parse easting, northing, and height (m) from a ``.sit`` coordinates line."""
+    coords_str = re.split(r"\s+", line.strip())[0:3]
+    return float(coords_str[0]), float(coords_str[1]), float(coords_str[2])

--- a/nps_active_space/setup/site_decoder.py
+++ b/nps_active_space/setup/site_decoder.py
@@ -1,0 +1,267 @@
+"""Decode ``.sit`` UTM coordinates to geographic locations and diagnose legacy zone mismatches."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import geopandas as gpd
+from pyproj import Transformer
+from shapely.geometry import Point
+
+from nps_active_space.utils.computation import NMSIM_bbox_utm, coords_to_utm
+
+logger = logging.getLogger(__name__)
+
+SitCoordsStatus = Literal["ok", "legacy", "failed"]
+
+
+@dataclass(frozen=True)
+class SitFileContents:
+    """Parsed body of an NMSIM ``.sit`` listener-location file."""
+
+    header_line_1: str
+    header_line_2: str
+    easting_m: float
+    northing_m: float
+    height_agl_m: float
+    label: str
+    dem_flt_path: str
+
+
+def parse_sit_coords_line(line: str) -> tuple[float, float, float]:
+    """Parse easting, northing, and height (m) from a ``.sit`` coordinates line."""
+    coords_str = re.split(r"\s+", line.strip())[0:3]
+    return float(coords_str[0]), float(coords_str[1]), float(coords_str[2])
+
+
+def parse_sit_label(coords_line: str) -> str:
+    """Parse the trailing listener label from a ``.sit`` coordinates line."""
+    tokens = coords_line.strip().split()
+    if len(tokens) < 4:
+        return ""
+    return tokens[3]
+
+
+def read_sit_file(sit_path: str | Path) -> SitFileContents:
+    """Read and parse an NMSIM ``.sit`` listener-location file."""
+    sit_path = Path(sit_path)
+    lines = sit_path.read_text().splitlines()
+    if len(lines) < 4:
+        raise ValueError(
+            f"Microphone site file has invalid format (expected coordinates on line 3):\n"
+            f"  {sit_path}"
+        )
+    coords_line = lines[2]
+    easting_m, northing_m, height_agl_m = parse_sit_coords_line(coords_line)
+    return SitFileContents(
+        header_line_1=lines[0],
+        header_line_2=lines[1],
+        easting_m=easting_m,
+        northing_m=northing_m,
+        height_agl_m=height_agl_m,
+        label=parse_sit_label(coords_line),
+        dem_flt_path=lines[3],
+    )
+
+
+def study_area_corner_coords_wgs84(
+    study_area: gpd.GeoDataFrame,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return study-area SW and NE corners as ``(lon, lat)`` in WGS84."""
+    minx, miny, maxx, maxy = study_area.to_crs("EPSG:4326").total_bounds
+    return (minx, miny), (maxx, maxy)
+
+
+def format_project_setup_command(
+    unit: str,
+    site: str,
+    year: int,
+    mic_coord: tuple[float, float],
+    studyarea_sw: tuple[float, float],
+    studyarea_ne: tuple[float, float],
+) -> str:
+    """Return a copy-paste ``project_setup`` invocation for the given deployment."""
+    mic_lon, mic_lat = mic_coord
+    sw_lon, sw_lat = studyarea_sw
+    ne_lon, ne_lat = studyarea_ne
+    return (
+        f"python -m nps_active_space.scripts.project_setup -e <environment> "
+        f"-u {unit} -s {site} -y {year} "
+        f"--mic-coord {mic_lon:.8f} {mic_lat:.8f} "
+        f"--studyarea-sw {sw_lon:.8f} {sw_lat:.8f} "
+        f"--studyarea-ne {ne_lon:.8f} {ne_lat:.8f}"
+    )
+
+
+def _utm_epsg_candidates_for_study_area(study_area: gpd.GeoDataFrame) -> list[str]:
+    """UTM EPSG codes that may span the study-area bbox, with project zone first."""
+    study_nad83 = study_area if study_area.crs.to_epsg() == 4269 else study_area.to_crs(4269)
+    minx, miny, maxx, maxy = study_nad83.total_bounds
+    project_utm = NMSIM_bbox_utm(study_area)
+    candidates: list[str] = []
+
+    for lon, lat in ((minx, miny), (minx, maxy), (maxx, miny), (maxx, maxy)):
+        epsg, _ = coords_to_utm(lat=lat, lon=lon)
+        if epsg not in candidates:
+            candidates.append(epsg)
+
+    if project_utm in candidates:
+        candidates.remove(project_utm)
+    return [project_utm, *candidates]
+
+
+def _lonlat_in_study_area(lon: float, lat: float, study_area: gpd.GeoDataFrame) -> bool:
+    study_polygon = study_area.to_crs("EPSG:4326").union_all()
+    return study_polygon.contains(Point(lon, lat))
+
+
+def _sit_utm_to_lonlat(
+    easting_m: float,
+    northing_m: float,
+    utm_epsg: str,
+) -> tuple[float, float]:
+    """Transform ``.sit`` easting/northing in ``utm_epsg`` to WGS84 lon/lat."""
+    return Transformer.from_crs(utm_epsg, "EPSG:4326", always_xy=True).transform(
+        easting_m, northing_m
+    )
+
+
+def _decode_sit_lonlat(
+    easting_m: float,
+    northing_m: float,
+    study_area: gpd.GeoDataFrame,
+) -> tuple[float, float, str] | None:
+    """Return ``(lon, lat, utm_epsg)`` for the first zone placing the point in the study area."""
+    for utm_epsg in _utm_epsg_candidates_for_study_area(study_area):
+        lon, lat = _sit_utm_to_lonlat(easting_m, northing_m, utm_epsg)
+        if _lonlat_in_study_area(lon, lat, study_area):
+            return lon, lat, utm_epsg
+    return None
+
+
+def diagnose_sit_coords(
+    easting_m: float,
+    northing_m: float,
+    study_area: gpd.GeoDataFrame,
+) -> tuple[SitCoordsStatus, float, float, str, str | None]:
+    """
+    Classify ``.sit`` easting/northing without raising.
+
+    Returns ``(status, lon, lat, project_utm, decoded_utm)``.
+    """
+    project_utm = NMSIM_bbox_utm(study_area)
+    decoded = _decode_sit_lonlat(easting_m, northing_m, study_area)
+    if decoded is not None:
+        lon, lat, decoded_utm = decoded
+        if decoded_utm == project_utm:
+            return "ok", lon, lat, project_utm, decoded_utm
+        return "legacy", lon, lat, project_utm, decoded_utm
+
+    lon, lat = _sit_utm_to_lonlat(easting_m, northing_m, project_utm)
+    return "failed", lon, lat, project_utm, None
+
+
+def project_zone_utm_coords(
+    lon: float,
+    lat: float,
+    study_area: gpd.GeoDataFrame,
+) -> tuple[float, float]:
+    """Project WGS84 lon/lat to the NMSIM project UTM zone for ``study_area``."""
+    project_utm = NMSIM_bbox_utm(study_area)
+    easting_m, northing_m = Transformer.from_crs(
+        "EPSG:4326", project_utm, always_xy=True
+    ).transform(lon, lat)
+    return easting_m, northing_m
+
+
+def _raise_sit_coords_error(
+    *,
+    sit_path: Path,
+    headline: str,
+    detail: str,
+    unit: str,
+    site: str,
+    year: int,
+    mic_coord: tuple[float, float],
+    study_area: gpd.GeoDataFrame,
+) -> None:
+    """Log a warning and raise with a copy-paste ``project_setup`` command."""
+    studyarea_sw, studyarea_ne = study_area_corner_coords_wgs84(study_area)
+    setup_cmd = format_project_setup_command(
+        unit,
+        site,
+        year,
+        mic_coord=mic_coord,
+        studyarea_sw=studyarea_sw,
+        studyarea_ne=studyarea_ne,
+    )
+    message = (
+        f"{headline}\n"
+        f"  {sit_path}\n"
+        f"{detail}"
+        f"Re-run project setup to rewrite the .sit file:\n"
+        f"  {setup_cmd}"
+    )
+    logger.warning(message)
+    raise ValueError(message)
+
+
+def decode_sit_geographic_coords(
+    easting_m: float,
+    northing_m: float,
+    study_area: gpd.GeoDataFrame,
+    *,
+    sit_path: str | Path,
+    unit: str,
+    site: str,
+    year: int,
+) -> tuple[float, float]:
+    """
+    Decode ``.sit`` easting/northing to WGS84 lon/lat using the NMSIM project UTM zone.
+
+    Raises
+    ------
+    ValueError
+        If coords appear to use a legacy mic-local UTM zone, with a ``project_setup`` command to rerun.
+    """
+    sit_path = Path(sit_path)
+    status, lon, lat, project_utm, decoded_utm = diagnose_sit_coords(
+        easting_m, northing_m, study_area
+    )
+    if status == "ok":
+        return lon, lat
+    if status == "legacy":
+        _raise_sit_coords_error(
+            sit_path=sit_path,
+            headline="Microphone site file uses legacy mic-local UTM coordinates:",
+            detail=(
+                f"Decoded as {decoded_utm}, but NMSIM expects the project zone {project_utm} "
+                f"(western edge of the study area).\n"
+            ),
+            unit=unit,
+            site=site,
+            year=year,
+            mic_coord=(lon, lat),
+            study_area=study_area,
+        )
+
+    _raise_sit_coords_error(
+        sit_path=sit_path,
+        headline=(
+            "Microphone site file coordinates do not fall inside the study area when decoded "
+            f"with the NMSIM project UTM zone {project_utm}:"
+        ),
+        detail=(
+            f"Decoded location: lon={lon:.6f}, lat={lat:.6f}\n"
+            "This deployment may have been created before the project-zone .sit fix.\n"
+        ),
+        unit=unit,
+        site=site,
+        year=year,
+        mic_coord=(lon, lat),
+        study_area=study_area,
+    )

--- a/nps_active_space/setup/site_migrate.py
+++ b/nps_active_space/setup/site_migrate.py
@@ -1,0 +1,220 @@
+"""Rewrite legacy ``.sit`` files to use the NMSIM project UTM zone."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import geopandas as gpd
+
+from nps_active_space.setup.site_decoder import (
+    diagnose_sit_coords,
+    format_project_setup_command,
+    project_zone_utm_coords,
+    read_sit_file,
+    study_area_corner_coords_wgs84,
+)
+from nps_active_space.setup.site_writer import (
+    deployment_sit_name,
+    sit_file_path,
+    write_site_file,
+)
+from nps_active_space.utils.helpers import load_studyarea
+
+logger = logging.getLogger(__name__)
+
+SitMigrationAction = Literal["skipped_ok", "migrated", "dry_run_would_migrate", "failed"]
+
+
+@dataclass(frozen=True)
+class SitMigrationResult:
+    """Outcome of migrating one deployment ``.sit`` file."""
+
+    unit: str
+    site: str
+    year: int
+    sit_path: Path
+    action: SitMigrationAction
+    project_utm: str
+    decoded_utm: str | None = None
+    lon: float | None = None
+    lat: float | None = None
+    message: str | None = None
+
+
+def discover_deployment_sits(project_dir: str | Path) -> list[tuple[str, str, int, Path]]:
+    """
+    Find canonical deployment ``.sit`` files under ``project_dir``.
+
+    Returns sorted ``(unit, site, year, sit_path)`` tuples.
+    """
+    project_dir = Path(project_dir)
+    deployments: list[tuple[str, str, int, Path]] = []
+
+    for sit_path in sorted(project_dir.glob("*/Input_Data/05_SITES/*.sit")):
+        site_folder = sit_path.parents[2].name
+        stem = sit_path.stem
+        if len(stem) < 5 or not stem[-4:].isdigit():
+            logger.warning("Skipping non-canonical .sit file: %s", sit_path)
+            continue
+
+        year = int(stem[-4:])
+        unit_site = stem[:-4]
+        if unit_site != site_folder or len(unit_site) < 5:
+            logger.warning("Skipping non-canonical .sit file: %s", sit_path)
+            continue
+
+        unit, site = unit_site[:4], unit_site[4:]
+        deployments.append((unit, site, year, sit_path))
+
+    return deployments
+
+
+def migrate_sit_file(
+    sit_path: str | Path,
+    study_area: gpd.GeoDataFrame,
+    *,
+    unit: str,
+    site: str,
+    year: int,
+    dry_run: bool = False,
+) -> SitMigrationResult:
+    """Rewrite a legacy ``.sit`` file to use the NMSIM project UTM zone when needed."""
+    sit_path = Path(sit_path)
+    sit_contents = read_sit_file(sit_path)
+    status, lon, lat, project_utm, decoded_utm = diagnose_sit_coords(
+        sit_contents.easting_m,
+        sit_contents.northing_m,
+        study_area,
+    )
+
+    if status == "ok":
+        return SitMigrationResult(
+            unit=unit,
+            site=site,
+            year=year,
+            sit_path=sit_path,
+            action="skipped_ok",
+            project_utm=project_utm,
+            decoded_utm=decoded_utm,
+            lon=lon,
+            lat=lat,
+        )
+
+    if status == "failed":
+        studyarea_sw, studyarea_ne = study_area_corner_coords_wgs84(study_area)
+        message = (
+            "Could not decode .sit coordinates inside the study area. "
+            "Re-run project_setup manually:\n"
+            f"  {format_project_setup_command(unit, site, year, (lon, lat), studyarea_sw, studyarea_ne)}"
+        )
+        return SitMigrationResult(
+            unit=unit,
+            site=site,
+            year=year,
+            sit_path=sit_path,
+            action="failed",
+            project_utm=project_utm,
+            decoded_utm=decoded_utm,
+            lon=lon,
+            lat=lat,
+            message=message,
+        )
+
+    easting_m, northing_m = project_zone_utm_coords(lon, lat, study_area)
+    if not dry_run:
+        write_site_file(
+            sit_path,
+            easting_m,
+            northing_m,
+            sit_contents.height_agl_m,
+            sit_contents.label,
+            sit_contents.dem_flt_path,
+        )
+
+    return SitMigrationResult(
+        unit=unit,
+        site=site,
+        year=year,
+        sit_path=sit_path,
+        action="dry_run_would_migrate" if dry_run else "migrated",
+        project_utm=project_utm,
+        decoded_utm=decoded_utm,
+        lon=lon,
+        lat=lat,
+        message=f"{decoded_utm} -> {project_utm}",
+    )
+
+
+def migrate_deployment_sit(
+    project_dir: str | Path,
+    unit: str,
+    site: str,
+    year: int,
+    *,
+    dry_run: bool = False,
+) -> SitMigrationResult:
+    """Migrate the canonical ``.sit`` file for one deployment."""
+    project_dir = Path(project_dir)
+    site_dir = project_dir / f"{unit}{site}"
+    sit_path = sit_file_path(site_dir, deployment_sit_name(unit, site, year))
+    if not sit_path.is_file():
+        return SitMigrationResult(
+            unit=unit,
+            site=site,
+            year=year,
+            sit_path=sit_path,
+            action="failed",
+            project_utm="",
+            message=f"Microphone site file not found: {sit_path}",
+        )
+
+    study_area = load_studyarea(str(project_dir), unit, site, year)
+    return migrate_sit_file(
+        sit_path,
+        study_area,
+        unit=unit,
+        site=site,
+        year=year,
+        dry_run=dry_run,
+    )
+
+
+def migrate_project_sites(
+    project_dir: str | Path,
+    *,
+    deployments: list[tuple[str, str, int]] | None = None,
+    dry_run: bool = False,
+) -> list[SitMigrationResult]:
+    """Migrate one or all deployments under ``project_dir``."""
+    project_dir = Path(project_dir)
+    discovered = discover_deployment_sits(project_dir)
+    if deployments is None:
+        selected = discovered
+    else:
+        requested = set(deployments)
+        selected = [
+            (unit, site, year, sit_path)
+            for unit, site, year, sit_path in discovered
+            if (unit, site, year) in requested
+        ]
+        missing = requested - {(unit, site, year) for unit, site, year, _ in selected}
+        for unit, site, year in sorted(missing):
+            logger.warning("No canonical .sit found for %s%s%s", unit, site, year)
+
+    results: list[SitMigrationResult] = []
+    for unit, site, year, sit_path in selected:
+        study_area = load_studyarea(str(project_dir), unit, site, year)
+        results.append(
+            migrate_sit_file(
+                sit_path,
+                study_area,
+                unit=unit,
+                site=site,
+                year=year,
+                dry_run=dry_run,
+            )
+        )
+    return results

--- a/nps_active_space/setup/site_writer.py
+++ b/nps_active_space/setup/site_writer.py
@@ -1,8 +1,7 @@
-"""NMSIM site directory, study area, and .sit file helpers."""
+"""Create NMSIM site directory layout, study area shapefiles, and ``.sit`` listener files."""
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import geopandas as gpd
@@ -29,12 +28,10 @@ NMSIM_SITE_SUBFOLDERS = [
 
 
 def deployment_sit_name(unit: str, site: str, year: int) -> str:
-    """Return the canonical NMSIM ``.sit`` basename (without extension) for a deployment."""
     return f"{unit}{site}{year}"
 
 
 def sit_file_path(site_dir: str | Path, sit_name: str) -> Path:
-    """Return ``{site_dir}/Input_Data/05_SITES/{sit_name}.sit``."""
     return Path(site_dir) / NMSIM_SITES_DIR / f"{sit_name}.sit"
 
 
@@ -168,9 +165,9 @@ def create_site_file(
     year : int
         Four digit deployment year, e.g. 2018.
     easting_m : float
-        UTM easting in meters (microphone's UTM zone).
+        UTM easting in meters (project UTM zone from the study area's western edge).
     northing_m : float
-        UTM northing in meters (microphone's UTM zone).
+        UTM northing in meters (project UTM zone from the study area's western edge).
     height : float
         Microphone height in meters; defaults to ANSI standard, 1.5 meters.
     dem_flt_path : str | Path, optional
@@ -198,9 +195,3 @@ def create_site_file(
         dem_flt_path,
         label=unit + site,
     )
-
-
-def parse_sit_coords_line(line: str) -> tuple[float, float, float]:
-    """Parse easting, northing, and height (m) from a ``.sit`` coordinates line."""
-    coords_str = re.split(r"\s+", line.strip())[0:3]
-    return float(coords_str[0]), float(coords_str[1]), float(coords_str[2])

--- a/nps_active_space/setup/workflow.py
+++ b/nps_active_space/setup/workflow.py
@@ -1,0 +1,155 @@
+"""
+Orchestrate the full NMSIM project setup workflow.
+
+This requires two conceptual inputs: (1) a study area polygon, and (2) a listening location point.
+We use the study area to prepare a portion of a Digital Elevation Model for use in computation and visualization.
+The elevation data is also converted to an antiquated ESRI GridFloat format required by ``NMSIM``.
+We represent the listening location coordinates as a canonical NMSIM site (.sit) file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import geopandas as gpd
+from shapely.geometry import Point
+
+from nps_active_space.setup.elevation import (
+    GRIDFLOAT_NODATA,
+    NMSIM_DST_CRS,
+    NODATA_INT16,
+    create_elevation_tif,
+    write_gridfloat,
+)
+from nps_active_space.setup.site import (
+    create_site_dir,
+    create_site_file,
+    create_study_area,
+    deployment_sit_name,
+    sit_file_path,
+)
+from nps_active_space.utils.computation import coords_to_utm
+from nps_active_space.utils.enums import SourceElevationUnits
+
+
+@dataclass(frozen=True)
+class SetupSiteResult:
+    """Paths and in-memory artifacts produced by :func:`setup_site`."""
+
+    study_area_wgs84: gpd.GeoDataFrame
+    study_area_path: Path
+    elevation_tif_path: Path
+    sit_path: Path
+
+
+def setup_site(
+    site_dir: str | Path,
+    unit: str,
+    site: str,
+    year: int,
+    mic_coord: tuple[float, float],
+    studyarea_sw: tuple[float, float],
+    studyarea_ne: tuple[float, float],
+    source_dem: str | Path,
+    dst_crs: str = NMSIM_DST_CRS,
+    mic_height_agl_m: float = 1.5,
+    source_elevation_units: SourceElevationUnits = SourceElevationUnits.FEET,
+) -> SetupSiteResult:
+    """
+    Run the full NMSIM site setup workflow for a new deployment directory.
+
+    Creates the canonical site directory tree, study area shapefile, clipped/reprojected
+    elevation GeoTIFF, GridFloat (.flt/.hdr), and microphone .sit file.
+
+    Parameters
+    ----------
+    site_dir : str | Path
+        Canonical NMSIM site directory (e.g. ``.../DENATRLA``).
+    unit : str
+        Four-character NPS Alpha Code, e.g. ``DENA``.
+    site : str
+        Alpha-numeric acoustic monitoring site code, e.g. ``TRLA``.
+    year : int
+        Four-digit deployment year, e.g. 2018.
+    mic_coord : tuple[float, float]
+        Microphone location as ``(lon, lat)`` in WGS84 decimal degrees.
+    studyarea_sw : tuple[float, float]
+        Study area southwest corner as ``(lon, lat)`` in WGS84.
+    studyarea_ne : tuple[float, float]
+        Study area northeast corner as ``(lon, lat)`` in WGS84.
+    source_dem : str | Path
+        Path to the source DEM raster. Elevation values must be in ``source_elevation_units``.
+    dst_crs : str, default ``EPSG:4269``
+        Coordinate reference system for the output elevation GeoTIFF.
+    mic_height_agl_m : float, default 1.5
+        Microphone height above ground in meters (ANSI standard).
+    source_elevation_units : SourceElevationUnits, default ``FEET``
+        Vertical units of ``source_dem``. ``project_setup.py`` reads ``dem_elevation_units``
+        from the environment config; library callers may override.
+
+    Returns
+    -------
+    SetupSiteResult
+        Study area geometry plus paths to written study area, elevation, and ``.sit`` files.
+    """
+    site_dir = Path(site_dir)
+    create_site_dir(site_dir)
+
+    study_area_wgs84 = create_study_area(
+        site_dir=site_dir,
+        unit=unit,
+        site=site,
+        year=year,
+        study_area_sw_corner=studyarea_sw,
+        study_area_ne_corner=studyarea_ne,
+    )
+
+    # to create a .sit file, we will eventually need the UTM coordinates of the microphone...
+    utm_epsg, _ = coords_to_utm(lat=mic_coord[1], lon=mic_coord[0])
+    mic_utm = gpd.GeoSeries([Point(mic_coord)], crs="EPSG:4326").to_crs(utm_epsg)
+
+    # quirk: `NMSIM` expects the elevation input's spatial reference to be the UTM Zone of the westernmost exent
+    #         this is occasionally different than the microphone's UTM Zone in the .sit file
+    _, utm_zone_str = coords_to_utm(lat=studyarea_sw[1], lon=studyarea_sw[0])
+    output_base = site_dir / "Input_Data" / "01_ELEVATION" / f"elevation_m_nad83_utm{utm_zone_str}"
+    output_tif = output_base.with_suffix(".tif")
+
+    dst_int16, dst_transform, dst_width, dst_height = create_elevation_tif(
+        source_dem=source_dem,
+        study_area_wgs84=study_area_wgs84,
+        dst_crs=dst_crs,
+        output_tif=output_tif,
+        nodata_int16=NODATA_INT16,
+        source_elevation_units=source_elevation_units,
+    )
+
+    # TODO when a National Landcover Database (NLCD) mapping has been construed, an equivalent
+    # `create_NMSIM_landcover_tif` function would belong here...
+
+    write_gridfloat(
+        output_base=output_base,
+        dst_int16=dst_int16,
+        dst_transform=dst_transform,
+        dst_width=dst_width,
+        dst_height=dst_height,
+        nodata_int16=NODATA_INT16,
+        gridfloat_nodata=GRIDFLOAT_NODATA,
+    )
+
+    create_site_file(
+        site_dir=site_dir,
+        unit=unit,
+        site=site,
+        year=year,
+        easting_m=mic_utm.x.item(),
+        northing_m=mic_utm.y.item(),
+        height=mic_height_agl_m,
+    )
+
+    return SetupSiteResult(
+        study_area_wgs84=study_area_wgs84,
+        study_area_path=site_dir / f"{unit}{site}_study_area.shp",
+        elevation_tif_path=output_tif,
+        sit_path=sit_file_path(site_dir, deployment_sit_name(unit, site, year)),
+    )

--- a/nps_active_space/setup/workflow.py
+++ b/nps_active_space/setup/workflow.py
@@ -22,14 +22,14 @@ from nps_active_space.setup.elevation import (
     create_elevation_tif,
     write_gridfloat,
 )
-from nps_active_space.setup.site import (
+from nps_active_space.setup.site_writer import (
     create_site_dir,
     create_site_file,
     create_study_area,
     deployment_sit_name,
     sit_file_path,
 )
-from nps_active_space.utils.computation import coords_to_utm
+from nps_active_space.utils.computation import NMSIM_bbox_utm, coords_to_utm
 from nps_active_space.utils.enums import SourceElevationUnits
 
 
@@ -105,12 +105,12 @@ def setup_site(
         study_area_ne_corner=studyarea_ne,
     )
 
-    # to create a .sit file, we will eventually need the UTM coordinates of the microphone...
-    utm_epsg, _ = coords_to_utm(lat=mic_coord[1], lon=mic_coord[0])
-    mic_utm = gpd.GeoSeries([Point(mic_coord)], crs="EPSG:4326").to_crs(utm_epsg)
+    # NMSIM references the project to the UTM zone of the study area's western edge; use that same CRS
+    # for both the elevation GridFloat and the microphone coordinates in the .sit file.
+    study_area_nad83 = study_area_wgs84.to_crs(epsg=4269)
+    project_utm = NMSIM_bbox_utm(study_area_nad83)
+    mic_utm = gpd.GeoSeries([Point(mic_coord)], crs="EPSG:4326").to_crs(project_utm)
 
-    # quirk: `NMSIM` expects the elevation input's spatial reference to be the UTM Zone of the westernmost exent
-    #         this is occasionally different than the microphone's UTM Zone in the .sit file
     _, utm_zone_str = coords_to_utm(lat=studyarea_sw[1], lon=studyarea_sw[0])
     output_base = site_dir / "Input_Data" / "01_ELEVATION" / f"elevation_m_nad83_utm{utm_zone_str}"
     output_tif = output_base.with_suffix(".tif")

--- a/nps_active_space/utils/config.py
+++ b/nps_active_space/utils/config.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from configparser import ConfigParser
 from typing import Any, Dict, Optional, Union
+
 from nps_active_space import ACTIVE_SPACE_DIR
+from nps_active_space.utils.enums import SourceElevationUnits
 import os
 
 __all__ = [
     'initialize',
-    'read'
+    'read',
+    'read_dem_elevation_units',
 ]
 
 _config = None
@@ -67,3 +72,18 @@ def read(section: str, option: Optional[str] = None) -> Union[Dict, Any]:
         return _config.get(section, option)
     else:
         return dict(_config.items(section))
+
+
+def read_dem_elevation_units() -> SourceElevationUnits:
+    """
+    Read ``dem_elevation_units`` from the loaded config's ``[data]`` section.
+
+    Defaults to ``"feet"`` when the option is missing or blank.
+    """
+    assert _config, "Config file initialization required before reading."
+
+    if _config.has_option("data", "dem_elevation_units"):
+        raw = _config.get("data", "dem_elevation_units").strip()
+        if raw:
+            return SourceElevationUnits.parse_config_value(raw)
+    return SourceElevationUnits.FEET

--- a/nps_active_space/utils/enums.py
+++ b/nps_active_space/utils/enums.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
 from enum import StrEnum
+
+
+FEET_TO_METERS = 0.3048
 
 
 class TrackSource(StrEnum):
@@ -7,3 +12,23 @@ class TrackSource(StrEnum):
     GPS = 'GPS'
     ADSB = 'ADSB'
     AIS = 'AIS'
+
+
+class SourceElevationUnits(StrEnum):
+    """Vertical units of a source DEM raster before conversion to meters."""
+
+    FEET = "feet"
+    METERS = "meters"
+
+    def to_meters_scale(self) -> float:
+        return FEET_TO_METERS if self is SourceElevationUnits.FEET else 1.0
+
+    @classmethod
+    def parse_config_value(cls, units: str) -> SourceElevationUnits:
+        """Parse a ``dem_elevation_units`` config string."""
+        try:
+            return cls(units.strip().lower())
+        except ValueError as exc:
+            raise ValueError(
+                f"dem_elevation_units must be 'feet' or 'meters', got {units!r}"
+            ) from exc

--- a/nps_active_space/utils/helpers.py
+++ b/nps_active_space/utils/helpers.py
@@ -20,7 +20,7 @@ from shapely.geometry import box
 from nps_active_space import ACTIVE_SPACE_DIR
 from nps_active_space.active_space import LayeredActiveSpace
 from nps_active_space.utils.models import Adsb, EarlyAdsb, Microphone, Annotations
-from nps_active_space.setup.site_decoder import decode_sit_geographic_coords, parse_sit_coords_line
+from nps_active_space.setup.site_decoder import decode_sit_geographic_coords, read_sit_file
 from nps_active_space.setup.site_writer import (
     NMSIM_SITES_DIR,
     deployment_sit_name,
@@ -249,15 +249,8 @@ def get_deployment(project_dir: str, unit: str, site: str, year: int, elevation:
             f"Microphone site file not found:\n  {mic_location_path}\n"
             f"Expected NMSIM .sit file at {NMSIM_SITES_DIR}/{deployment_sit_name(unit, site, year)}.sit"
         )
-    raw_text = Path(mic_location_path).read_text()
-    sit_lines = raw_text.splitlines()
-    if len(sit_lines) < 3:
-        raise ValueError(
-            f"Microphone site file has invalid format (expected coordinates on line 3):\n"
-            f"  {mic_location_path}"
-        )
-    coords_line = sit_lines[2]
-    x, y, z_agl = parse_sit_coords_line(coords_line)
+    sit_contents = read_sit_file(mic_location_path)
+    x, y, z_agl = sit_contents.easting_m, sit_contents.northing_m, sit_contents.height_agl_m
 
     # get lat/lon so we can initialize a Microphone object, need to get crs of the .SIT file first
     study_area = load_studyarea(project_dir, unit, site, year)

--- a/nps_active_space/utils/helpers.py
+++ b/nps_active_space/utils/helpers.py
@@ -20,7 +20,12 @@ from shapely.geometry import box
 from nps_active_space import ACTIVE_SPACE_DIR
 from nps_active_space.active_space import LayeredActiveSpace
 from nps_active_space.utils.models import Adsb, EarlyAdsb, Microphone, Annotations
-from nps_active_space.setup.site import NMSIM_SITES_DIR, deployment_sit_name, parse_sit_coords_line, sit_file_path
+from nps_active_space.setup.site_decoder import decode_sit_geographic_coords, parse_sit_coords_line
+from nps_active_space.setup.site_writer import (
+    NMSIM_SITES_DIR,
+    deployment_sit_name,
+    sit_file_path,
+)
 from nps_active_space.utils.computation import NMSIM_bbox_utm
 
 if TYPE_CHECKING:
@@ -257,8 +262,15 @@ def get_deployment(project_dir: str, unit: str, site: str, year: int, elevation:
     # get lat/lon so we can initialize a Microphone object, need to get crs of the .SIT file first
     study_area = load_studyarea(project_dir, unit, site, year)
     mic_crs = NMSIM_bbox_utm(study_area)
-    proj = Transformer.from_crs(mic_crs, "epsg:4326", always_xy=True)
-    lon, lat = proj.transform(x, y)
+    lon, lat = decode_sit_geographic_coords(
+        x,
+        y,
+        study_area,
+        sit_path=mic_location_path,
+        unit=unit,
+        site=site,
+        year=year,
+    )
 
     # calculate elevation from the DEM if necessary
     if elevation:

--- a/nps_active_space/utils/helpers.py
+++ b/nps_active_space/utils/helpers.py
@@ -20,6 +20,7 @@ from shapely.geometry import box
 from nps_active_space import ACTIVE_SPACE_DIR
 from nps_active_space.active_space import LayeredActiveSpace
 from nps_active_space.utils.models import Adsb, EarlyAdsb, Microphone, Annotations
+from nps_active_space.setup.site import NMSIM_SITES_DIR, deployment_sit_name, parse_sit_coords_line, sit_file_path
 from nps_active_space.utils.computation import NMSIM_bbox_utm
 
 if TYPE_CHECKING:
@@ -234,13 +235,14 @@ def get_deployment(project_dir: str, unit: str, site: str, year: int, elevation:
     """
 
     # Read the .SIT file containing x, y, and z AGL in NMSIM's CRS
-    mic_location_path = os.path.join(
-        project_dir, unit + site, "Input_Data", "05_SITES", f"{unit}{site}{year}.sit"
+    mic_location_path = sit_file_path(
+        Path(project_dir) / (unit + site),
+        deployment_sit_name(unit, site, year),
     )
-    if not os.path.isfile(mic_location_path):
+    if not mic_location_path.is_file():
         raise FileNotFoundError(
             f"Microphone site file not found:\n  {mic_location_path}\n"
-            f"Expected NMSIM .sit file at Input_Data/05_SITES/{unit}{site}{year}.sit"
+            f"Expected NMSIM .sit file at {NMSIM_SITES_DIR}/{deployment_sit_name(unit, site, year)}.sit"
         )
     raw_text = Path(mic_location_path).read_text()
     sit_lines = raw_text.splitlines()
@@ -250,8 +252,7 @@ def get_deployment(project_dir: str, unit: str, site: str, year: int, elevation:
             f"  {mic_location_path}"
         )
     coords_line = sit_lines[2]
-    coords_str = re.split(r'\s+', coords_line)[1:-1]
-    x, y, z_agl = [float(i) for i in coords_str[:3]]
+    x, y, z_agl = parse_sit_coords_line(coords_line)
 
     # get lat/lon so we can initialize a Microphone object, need to get crs of the .SIT file first
     study_area = load_studyarea(project_dir, unit, site, year)

--- a/tests/setup/conftest.py
+++ b/tests/setup/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+_setup_tests = Path(__file__).resolve().parent
+if str(_setup_tests) not in sys.path:
+    sys.path.insert(0, str(_setup_tests))

--- a/tests/setup/fixtures.py
+++ b/tests/setup/fixtures.py
@@ -1,0 +1,48 @@
+"""Shared constants and helpers for setup tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from affine import Affine
+
+from nps_active_space.setup import NMSIM_DST_CRS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_PROJECT_DIR = REPO_ROOT / "example_data" / "site_projects"
+STUDY_BOUNDS_4269 = (-136.2, 58.4, -135.8, 58.8)
+# DENABULL-style bbox: mic in UTM zone 6, study-area western edge in zone 5.
+DENABULL_BOUNDS_4269 = (-150.2, 63.1, -149.1, 63.6)
+DENABULL_MIC_COORD = (-149.62901, 63.39192)
+DENABULL_STUDYAREA_SW = (-150.02907, 63.21250)
+DENABULL_STUDYAREA_NE = (-149.22895, 63.57134)
+
+
+def write_source_dem(
+    path: Path,
+    bounds_4269: tuple[float, float, float, float],
+    elevation: float,
+    cellsize_deg: float = 0.02,
+) -> None:
+    """Write a minimal single-band DEM in NAD83 geographic (EPSG:4269)."""
+    minx, miny, maxx, maxy = bounds_4269
+    width = max(2, int(np.ceil((maxx - minx) / cellsize_deg)))
+    height = max(2, int(np.ceil((maxy - miny) / cellsize_deg)))
+    transform = Affine(cellsize_deg, 0.0, minx, 0.0, -cellsize_deg, maxy)
+    data = np.full((height, width), elevation, dtype=np.float32)
+
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=height,
+        width=width,
+        count=1,
+        dtype="float32",
+        crs=NMSIM_DST_CRS,
+        transform=transform,
+        nodata=-9999.0,
+    ) as ds:
+        ds.write(data, 1)

--- a/tests/setup/test_setup.py
+++ b/tests/setup/test_setup.py
@@ -1,0 +1,191 @@
+"""Integration and contract tests for ``nps_active_space.setup``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import pytest
+import rasterio
+from affine import Affine
+from shapely.geometry import box
+
+from nps_active_space.setup import (
+    NMSIM_DST_CRS,
+    parse_sit_coords_line,
+    setup_site,
+)
+from nps_active_space.setup.elevation import NODATA_INT16, create_elevation_tif, write_gridfloat
+from nps_active_space.utils.computation import NMSIM_bbox_utm
+from nps_active_space.utils.enums import SourceElevationUnits
+from nps_active_space.utils.helpers import get_deployment, load_studyarea
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_PROJECT_DIR = REPO_ROOT / "example_data" / "site_projects"
+STUDY_BOUNDS_4269 = (-136.2, 58.4, -135.8, 58.8)
+
+
+def _write_source_dem(
+    path: Path,
+    bounds_4269: tuple[float, float, float, float],
+    elevation: float,
+    cellsize_deg: float = 0.02,
+) -> None:
+    """Write a minimal single-band DEM in NAD83 geographic (EPSG:4269)."""
+    minx, miny, maxx, maxy = bounds_4269
+    width = max(2, int(np.ceil((maxx - minx) / cellsize_deg)))
+    height = max(2, int(np.ceil((maxy - miny) / cellsize_deg)))
+    transform = Affine(cellsize_deg, 0.0, minx, 0.0, -cellsize_deg, maxy)
+    data = np.full((height, width), elevation, dtype=np.float32)
+
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=height,
+        width=width,
+        count=1,
+        dtype="float32",
+        crs=NMSIM_DST_CRS,
+        transform=transform,
+        nodata=-9999.0,
+    ) as ds:
+        ds.write(data, 1)
+
+
+class TestExampleDenatrlaArtifacts:
+    """Contract tests against checked-in example deployment data."""
+
+    def test_study_area_and_mic_crs_align(self):
+        study_area = load_studyarea(str(EXAMPLE_PROJECT_DIR), "DENA", "TRLA", 2025)
+        mic = get_deployment(str(EXAMPLE_PROJECT_DIR), "DENA", "TRLA", 2025, elevation=False)
+
+        assert study_area.crs.to_epsg() == 4269
+        assert mic.crs == NMSIM_bbox_utm(study_area)
+
+    def test_elevation_tif_is_nad83_geographic_not_utm(self):
+        tif_path = (
+            EXAMPLE_PROJECT_DIR
+            / "DENATRLA"
+            / "Input_Data"
+            / "01_ELEVATION"
+            / "elevation_m_nad83_utm6.tif"
+        )
+        with rasterio.open(tif_path) as ds:
+            assert ds.crs.to_epsg() == 4269
+            # Geographic CRS uses degree cell sizes, not meter-based UTM.
+            assert abs(ds.transform.a) < 1.0
+
+
+class TestCreateElevationUnits:
+    def test_converts_feet_source_to_meters(self, tmp_path):
+        dem_path = tmp_path / "source_dem.tif"
+        _write_source_dem(dem_path, bounds_4269=STUDY_BOUNDS_4269, elevation=5000.0)
+        study_area = gpd.GeoDataFrame(
+            {"Unit": ["T"], "Site": ["0001"], "Year": [2025]},
+            geometry=[box(-136.1, 58.5, -135.9, 58.7)],
+            crs="EPSG:4326",
+        )
+        output_tif = tmp_path / "elevation_m.tif"
+
+        create_elevation_tif(
+            source_dem=dem_path,
+            study_area_wgs84=study_area,
+            dst_crs=NMSIM_DST_CRS,
+            output_tif=output_tif,
+            nodata_int16=NODATA_INT16,
+            source_elevation_units=SourceElevationUnits.FEET,
+        )
+
+        with rasterio.open(output_tif) as ds:
+            values = ds.read(1, masked=True)
+            assert float(values.mean()) == pytest.approx(5000.0 * 0.3048, abs=1.0)
+
+    def test_passthrough_meters_source(self, tmp_path):
+        dem_path = tmp_path / "source_dem.tif"
+        _write_source_dem(dem_path, bounds_4269=STUDY_BOUNDS_4269, elevation=1000.0)
+        study_area = gpd.GeoDataFrame(
+            {"Unit": ["T"], "Site": ["0001"], "Year": [2025]},
+            geometry=[box(-136.1, 58.5, -135.9, 58.7)],
+            crs="EPSG:4326",
+        )
+        output_tif = tmp_path / "elevation_m.tif"
+
+        create_elevation_tif(
+            source_dem=dem_path,
+            study_area_wgs84=study_area,
+            dst_crs=NMSIM_DST_CRS,
+            output_tif=output_tif,
+            nodata_int16=NODATA_INT16,
+            source_elevation_units=SourceElevationUnits.METERS,
+        )
+
+        with rasterio.open(output_tif) as ds:
+            values = ds.read(1, masked=True)
+            assert float(values.mean()) == pytest.approx(1000.0, abs=1.0)
+
+
+class TestSetupSiteIntegration:
+    def test_mic_coords_round_trip_through_sit_file(self, tmp_path):
+        project_dir = tmp_path
+        unit, site, year = "TEST", "0001", 2025
+        site_dir = project_dir / f"{unit}{site}"
+
+        mic_coord = (-136.0, 58.6)
+        studyarea_sw = (-136.1, 58.5)
+        studyarea_ne = (-135.9, 58.7)
+
+        dem_path = tmp_path / "source_dem.tif"
+        _write_source_dem(dem_path, bounds_4269=STUDY_BOUNDS_4269, elevation=5000.0)
+
+        result = setup_site(
+            site_dir=site_dir,
+            unit=unit,
+            site=site,
+            year=year,
+            mic_coord=mic_coord,
+            studyarea_sw=studyarea_sw,
+            studyarea_ne=studyarea_ne,
+            source_dem=dem_path,
+        )
+
+        mic = get_deployment(str(project_dir), unit, site, year, elevation=False)
+        assert mic.lon == pytest.approx(mic_coord[0], abs=1e-4)
+        assert mic.lat == pytest.approx(mic_coord[1], abs=1e-4)
+
+        sit_lines = result.sit_path.read_text().splitlines()
+        _, _, height = parse_sit_coords_line(sit_lines[2])
+        assert height == pytest.approx(1.5)
+
+        flt_path = result.elevation_tif_path.with_suffix(".flt")
+        assert flt_path.exists()
+        assert flt_path.with_suffix(".hdr").exists()
+
+        with rasterio.open(result.elevation_tif_path) as ds:
+            assert ds.crs.to_epsg() == 4269
+
+        saved_study_area = gpd.read_file(result.study_area_path)
+        assert saved_study_area.crs.to_epsg() == 4269
+
+    def test_gridfloat_dimensions_match_header(self, tmp_path):
+        dst_int16 = np.array([[100, 200], [300, 32767]], dtype=np.int16)
+        dst_transform = Affine(0.0004, 0.0, -136.1, 0.0, -0.0004, 58.7)
+        output_base = tmp_path / "elevation_m_nad83_utm6"
+
+        write_gridfloat(
+            output_base=output_base,
+            dst_int16=dst_int16,
+            dst_transform=dst_transform,
+            dst_width=2,
+            dst_height=2,
+            nodata_int16=np.int16(32767),
+            gridfloat_nodata=np.float32(-32768.0),
+        )
+
+        flt = np.fromfile(output_base.with_suffix(".flt"), dtype=np.float32)
+        hdr_lines = {
+            line.split()[0]: line.split()[1]
+            for line in output_base.with_suffix(".hdr").read_text().splitlines()
+        }
+        assert flt.size == int(hdr_lines["ncols"]) * int(hdr_lines["nrows"])

--- a/tests/setup/test_setup.py
+++ b/tests/setup/test_setup.py
@@ -11,13 +11,10 @@ import rasterio
 from affine import Affine
 from shapely.geometry import Point, box
 
-from nps_active_space.setup import (
-    NMSIM_DST_CRS,
-    create_site_file,
-    parse_sit_coords_line,
-    setup_site,
-)
+from nps_active_space.setup import NMSIM_DST_CRS, setup_site
 from nps_active_space.setup.elevation import NODATA_INT16, create_elevation_tif, write_gridfloat
+from nps_active_space.setup.site_decoder import parse_sit_coords_line
+from nps_active_space.setup.site_writer import create_site_file
 from nps_active_space.utils.computation import NMSIM_bbox_utm, coords_to_utm
 from nps_active_space.utils.enums import SourceElevationUnits
 from nps_active_space.utils.helpers import get_deployment, load_studyarea

--- a/tests/setup/test_setup.py
+++ b/tests/setup/test_setup.py
@@ -9,50 +9,27 @@ import numpy as np
 import pytest
 import rasterio
 from affine import Affine
-from shapely.geometry import box
+from shapely.geometry import Point, box
 
 from nps_active_space.setup import (
     NMSIM_DST_CRS,
+    create_site_file,
     parse_sit_coords_line,
     setup_site,
 )
 from nps_active_space.setup.elevation import NODATA_INT16, create_elevation_tif, write_gridfloat
-from nps_active_space.utils.computation import NMSIM_bbox_utm
+from nps_active_space.utils.computation import NMSIM_bbox_utm, coords_to_utm
 from nps_active_space.utils.enums import SourceElevationUnits
 from nps_active_space.utils.helpers import get_deployment, load_studyarea
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-EXAMPLE_PROJECT_DIR = REPO_ROOT / "example_data" / "site_projects"
-STUDY_BOUNDS_4269 = (-136.2, 58.4, -135.8, 58.8)
-
-
-def _write_source_dem(
-    path: Path,
-    bounds_4269: tuple[float, float, float, float],
-    elevation: float,
-    cellsize_deg: float = 0.02,
-) -> None:
-    """Write a minimal single-band DEM in NAD83 geographic (EPSG:4269)."""
-    minx, miny, maxx, maxy = bounds_4269
-    width = max(2, int(np.ceil((maxx - minx) / cellsize_deg)))
-    height = max(2, int(np.ceil((maxy - miny) / cellsize_deg)))
-    transform = Affine(cellsize_deg, 0.0, minx, 0.0, -cellsize_deg, maxy)
-    data = np.full((height, width), elevation, dtype=np.float32)
-
-    with rasterio.open(
-        path,
-        "w",
-        driver="GTiff",
-        height=height,
-        width=width,
-        count=1,
-        dtype="float32",
-        crs=NMSIM_DST_CRS,
-        transform=transform,
-        nodata=-9999.0,
-    ) as ds:
-        ds.write(data, 1)
-
+from fixtures import (
+    DENABULL_BOUNDS_4269,
+    DENABULL_MIC_COORD,
+    DENABULL_STUDYAREA_NE,
+    DENABULL_STUDYAREA_SW,
+    EXAMPLE_PROJECT_DIR,
+    STUDY_BOUNDS_4269,
+    write_source_dem,
+)
 
 class TestExampleDenatrlaArtifacts:
     """Contract tests against checked-in example deployment data."""
@@ -79,9 +56,22 @@ class TestExampleDenatrlaArtifacts:
 
 
 class TestCreateElevationUnits:
-    def test_converts_feet_source_to_meters(self, tmp_path):
+    @pytest.mark.parametrize(
+        ("source_units", "source_elevation", "expected_mean"),
+        [
+            (SourceElevationUnits.FEET, 5000.0, 5000.0 * 0.3048),
+            (SourceElevationUnits.METERS, 1000.0, 1000.0),
+        ],
+    )
+    def test_converts_source_elevation_to_meters(
+        self,
+        tmp_path,
+        source_units,
+        source_elevation,
+        expected_mean,
+    ):
         dem_path = tmp_path / "source_dem.tif"
-        _write_source_dem(dem_path, bounds_4269=STUDY_BOUNDS_4269, elevation=5000.0)
+        write_source_dem(dem_path, bounds_4269=STUDY_BOUNDS_4269, elevation=source_elevation)
         study_area = gpd.GeoDataFrame(
             {"Unit": ["T"], "Site": ["0001"], "Year": [2025]},
             geometry=[box(-136.1, 58.5, -135.9, 58.7)],
@@ -95,35 +85,12 @@ class TestCreateElevationUnits:
             dst_crs=NMSIM_DST_CRS,
             output_tif=output_tif,
             nodata_int16=NODATA_INT16,
-            source_elevation_units=SourceElevationUnits.FEET,
+            source_elevation_units=source_units,
         )
 
         with rasterio.open(output_tif) as ds:
             values = ds.read(1, masked=True)
-            assert float(values.mean()) == pytest.approx(5000.0 * 0.3048, abs=1.0)
-
-    def test_passthrough_meters_source(self, tmp_path):
-        dem_path = tmp_path / "source_dem.tif"
-        _write_source_dem(dem_path, bounds_4269=STUDY_BOUNDS_4269, elevation=1000.0)
-        study_area = gpd.GeoDataFrame(
-            {"Unit": ["T"], "Site": ["0001"], "Year": [2025]},
-            geometry=[box(-136.1, 58.5, -135.9, 58.7)],
-            crs="EPSG:4326",
-        )
-        output_tif = tmp_path / "elevation_m.tif"
-
-        create_elevation_tif(
-            source_dem=dem_path,
-            study_area_wgs84=study_area,
-            dst_crs=NMSIM_DST_CRS,
-            output_tif=output_tif,
-            nodata_int16=NODATA_INT16,
-            source_elevation_units=SourceElevationUnits.METERS,
-        )
-
-        with rasterio.open(output_tif) as ds:
-            values = ds.read(1, masked=True)
-            assert float(values.mean()) == pytest.approx(1000.0, abs=1.0)
+            assert float(values.mean()) == pytest.approx(expected_mean, abs=1.0)
 
 
 class TestSetupSiteIntegration:
@@ -137,7 +104,7 @@ class TestSetupSiteIntegration:
         studyarea_ne = (-135.9, 58.7)
 
         dem_path = tmp_path / "source_dem.tif"
-        _write_source_dem(dem_path, bounds_4269=STUDY_BOUNDS_4269, elevation=5000.0)
+        write_source_dem(dem_path, bounds_4269=STUDY_BOUNDS_4269, elevation=5000.0)
 
         result = setup_site(
             site_dir=site_dir,
@@ -168,10 +135,87 @@ class TestSetupSiteIntegration:
         saved_study_area = gpd.read_file(result.study_area_path)
         assert saved_study_area.crs.to_epsg() == 4269
 
-    def test_gridfloat_dimensions_match_header(self, tmp_path):
+    def test_mic_coords_round_trip_when_mic_and_project_utm_zones_differ(self, tmp_path):
+        """Regression: .sit easting/northing must use the project UTM zone, not the mic's local zone."""
+        project_dir = tmp_path
+        unit, site, year = "DENA", "BULL", 2019
+        site_dir = project_dir / f"{unit}{site}"
+
+        mic_zone, _ = coords_to_utm(lat=DENABULL_MIC_COORD[1], lon=DENABULL_MIC_COORD[0])
+        project_zone, _ = coords_to_utm(
+            lat=DENABULL_STUDYAREA_SW[1], lon=DENABULL_STUDYAREA_SW[0]
+        )
+        assert mic_zone != project_zone
+
+        dem_path = tmp_path / "source_dem.tif"
+        write_source_dem(dem_path, bounds_4269=DENABULL_BOUNDS_4269, elevation=5000.0)
+
+        setup_site(
+            site_dir=site_dir,
+            unit=unit,
+            site=site,
+            year=year,
+            mic_coord=DENABULL_MIC_COORD,
+            studyarea_sw=DENABULL_STUDYAREA_SW,
+            studyarea_ne=DENABULL_STUDYAREA_NE,
+            source_dem=dem_path,
+        )
+
+        mic = get_deployment(str(project_dir), unit, site, year, elevation=False)
+        assert mic.lon == pytest.approx(DENABULL_MIC_COORD[0], abs=1e-4)
+        assert mic.lat == pytest.approx(DENABULL_MIC_COORD[1], abs=1e-4)
+
+    def test_legacy_mic_local_zone_sit_raises_with_project_setup_command(self, tmp_path):
+        project_dir = tmp_path
+        unit, site, year = "DENA", "BULL", 2019
+        site_dir = project_dir / f"{unit}{site}"
+
+        dem_path = tmp_path / "source_dem.tif"
+        write_source_dem(dem_path, bounds_4269=DENABULL_BOUNDS_4269, elevation=5000.0)
+
+        setup_site(
+            site_dir=site_dir,
+            unit=unit,
+            site=site,
+            year=year,
+            mic_coord=DENABULL_MIC_COORD,
+            studyarea_sw=DENABULL_STUDYAREA_SW,
+            studyarea_ne=DENABULL_STUDYAREA_NE,
+            source_dem=dem_path,
+        )
+
+        mic_zone, _ = coords_to_utm(lat=DENABULL_MIC_COORD[1], lon=DENABULL_MIC_COORD[0])
+        mic_utm = gpd.GeoSeries([Point(DENABULL_MIC_COORD)], crs="EPSG:4326").to_crs(mic_zone)
+        create_site_file(
+            site_dir=site_dir,
+            unit=unit,
+            site=site,
+            year=year,
+            easting_m=mic_utm.x.item(),
+            northing_m=mic_utm.y.item(),
+        )
+
+        with pytest.raises(ValueError, match="legacy mic-local UTM") as exc_info:
+            get_deployment(str(project_dir), unit, site, year, elevation=False)
+
+        message = str(exc_info.value)
+        assert "project_setup" in message
+        assert "epsg:26906" in message
+        assert "epsg:26905" in message
+        assert f"-u {unit} -s {site} -y {year}" in message
+        assert (
+            f"--studyarea-sw {DENABULL_STUDYAREA_SW[0]:.8f} {DENABULL_STUDYAREA_SW[1]:.8f}" in message
+        )
+        assert (
+            f"--studyarea-ne {DENABULL_STUDYAREA_NE[0]:.8f} {DENABULL_STUDYAREA_NE[1]:.8f}" in message
+        )
+
+    def test_write_gridfloat_encodes_geometry_and_nodata(self, tmp_path):
         dst_int16 = np.array([[100, 200], [300, 32767]], dtype=np.int16)
         dst_transform = Affine(0.0004, 0.0, -136.1, 0.0, -0.0004, 58.7)
         output_base = tmp_path / "elevation_m_nad83_utm6"
+        nodata_int16 = np.int16(32767)
+        gridfloat_nodata = np.float32(-32768.0)
 
         write_gridfloat(
             output_base=output_base,
@@ -179,13 +223,24 @@ class TestSetupSiteIntegration:
             dst_transform=dst_transform,
             dst_width=2,
             dst_height=2,
-            nodata_int16=np.int16(32767),
-            gridfloat_nodata=np.float32(-32768.0),
+            nodata_int16=nodata_int16,
+            gridfloat_nodata=gridfloat_nodata,
         )
 
-        flt = np.fromfile(output_base.with_suffix(".flt"), dtype=np.float32)
         hdr_lines = {
             line.split()[0]: line.split()[1]
             for line in output_base.with_suffix(".hdr").read_text().splitlines()
         }
-        assert flt.size == int(hdr_lines["ncols"]) * int(hdr_lines["nrows"])
+        assert int(hdr_lines["ncols"]) == 2
+        assert int(hdr_lines["nrows"]) == 2
+        assert float(hdr_lines["NODATA_value"]) == pytest.approx(float(gridfloat_nodata))
+        assert float(hdr_lines["xllcorner"]) == pytest.approx(dst_transform.c)
+        assert float(hdr_lines["yllcorner"]) == pytest.approx(dst_transform.f + 2 * dst_transform.e)
+        assert float(hdr_lines["cellsize"]) == pytest.approx(dst_transform.a)
+
+        flt = np.fromfile(output_base.with_suffix(".flt"), dtype=np.float32).reshape(2, 2)
+        assert flt[0, 0] == pytest.approx(100.0)
+        assert flt[0, 1] == pytest.approx(200.0)
+        assert flt[1, 0] == pytest.approx(300.0)
+        assert flt[1, 1] == pytest.approx(float(gridfloat_nodata))
+

--- a/tests/setup/test_site_migrate.py
+++ b/tests/setup/test_site_migrate.py
@@ -8,7 +8,8 @@ import geopandas as gpd
 import pytest
 from shapely.geometry import Point, box
 
-from nps_active_space.setup import create_site_file, setup_site
+from nps_active_space.setup import setup_site
+from nps_active_space.setup.site_writer import create_site_file
 from nps_active_space.setup.site_decoder import (
     diagnose_sit_coords,
     read_sit_file,

--- a/tests/setup/test_site_migrate.py
+++ b/tests/setup/test_site_migrate.py
@@ -1,0 +1,226 @@
+"""Tests for legacy ``.sit`` migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point, box
+
+from nps_active_space.setup import create_site_file, setup_site
+from nps_active_space.setup.site_decoder import (
+    diagnose_sit_coords,
+    read_sit_file,
+)
+from nps_active_space.setup.site_migrate import (
+    discover_deployment_sits,
+    migrate_deployment_sit,
+    migrate_project_sites,
+    migrate_sit_file,
+)
+from nps_active_space.utils.computation import coords_to_utm
+from nps_active_space.utils.helpers import get_deployment, load_studyarea
+from fixtures import (
+    DENABULL_BOUNDS_4269,
+    DENABULL_MIC_COORD,
+    DENABULL_STUDYAREA_NE,
+    DENABULL_STUDYAREA_SW,
+    STUDY_BOUNDS_4269,
+    write_source_dem,
+)
+
+def _create_denabull_deployment(project_dir: Path, *, legacy_sit: bool) -> tuple[str, str, int]:
+    unit, site, year = "DENA", "BULL", 2019
+    site_dir = project_dir / f"{unit}{site}"
+    dem_path = project_dir / "source_dem.tif"
+    write_source_dem(dem_path, bounds_4269=DENABULL_BOUNDS_4269, elevation=5000.0)
+
+    setup_site(
+        site_dir=site_dir,
+        unit=unit,
+        site=site,
+        year=year,
+        mic_coord=DENABULL_MIC_COORD,
+        studyarea_sw=DENABULL_STUDYAREA_SW,
+        studyarea_ne=DENABULL_STUDYAREA_NE,
+        source_dem=dem_path,
+    )
+
+    if legacy_sit:
+        mic_zone, _ = coords_to_utm(lat=DENABULL_MIC_COORD[1], lon=DENABULL_MIC_COORD[0])
+        mic_utm = gpd.GeoSeries([Point(DENABULL_MIC_COORD)], crs="EPSG:4326").to_crs(mic_zone)
+        create_site_file(
+            site_dir=site_dir,
+            unit=unit,
+            site=site,
+            year=year,
+            easting_m=mic_utm.x.item(),
+            northing_m=mic_utm.y.item(),
+        )
+
+    return unit, site, year
+
+
+class TestDiagnoseSitCoords:
+    def test_legacy_and_ok_statuses(self, tmp_path):
+        unit, site, year = _create_denabull_deployment(tmp_path, legacy_sit=True)
+        study_area = load_studyarea(str(tmp_path), unit, site, year)
+        sit_path = tmp_path / f"{unit}{site}" / "Input_Data" / "05_SITES" / f"{unit}{site}{year}.sit"
+        sit_contents = read_sit_file(sit_path)
+
+        status, lon, lat, project_utm, decoded_utm = diagnose_sit_coords(
+            sit_contents.easting_m,
+            sit_contents.northing_m,
+            study_area,
+        )
+        assert status == "legacy"
+        assert decoded_utm != project_utm
+        assert lon == pytest.approx(DENABULL_MIC_COORD[0], abs=1e-4)
+        assert lat == pytest.approx(DENABULL_MIC_COORD[1], abs=1e-4)
+
+        migrate_sit_file(
+            sit_path,
+            study_area,
+            unit=unit,
+            site=site,
+            year=year,
+        )
+        migrated = read_sit_file(sit_path)
+        status, _, _, _, decoded_utm = diagnose_sit_coords(
+            migrated.easting_m,
+            migrated.northing_m,
+            study_area,
+        )
+        assert status == "ok"
+        assert decoded_utm == project_utm
+
+
+class TestMigrateSitFile:
+    def test_migrates_legacy_sit_and_preserves_metadata(self, tmp_path):
+        unit, site, year = _create_denabull_deployment(tmp_path, legacy_sit=True)
+        study_area = load_studyarea(str(tmp_path), unit, site, year)
+        sit_path = tmp_path / f"{unit}{site}" / "Input_Data" / "05_SITES" / f"{unit}{site}{year}.sit"
+        before = read_sit_file(sit_path)
+
+        result = migrate_sit_file(
+            sit_path,
+            study_area,
+            unit=unit,
+            site=site,
+            year=year,
+        )
+
+        assert result.action == "migrated"
+        assert result.decoded_utm != result.project_utm
+        after = read_sit_file(sit_path)
+        assert after.label == before.label
+        assert after.height_agl_m == before.height_agl_m
+        assert after.dem_flt_path == before.dem_flt_path
+        assert (after.easting_m, after.northing_m) != (before.easting_m, before.northing_m)
+
+        mic = get_deployment(str(tmp_path), unit, site, year, elevation=False)
+        assert mic.lon == pytest.approx(DENABULL_MIC_COORD[0], abs=1e-4)
+        assert mic.lat == pytest.approx(DENABULL_MIC_COORD[1], abs=1e-4)
+
+    def test_skips_project_zone_sit(self, tmp_path):
+        unit, site, year = _create_denabull_deployment(tmp_path, legacy_sit=False)
+        study_area = load_studyarea(str(tmp_path), unit, site, year)
+        sit_path = tmp_path / f"{unit}{site}" / "Input_Data" / "05_SITES" / f"{unit}{site}{year}.sit"
+        before = read_sit_file(sit_path)
+
+        result = migrate_sit_file(
+            sit_path,
+            study_area,
+            unit=unit,
+            site=site,
+            year=year,
+        )
+
+        assert result.action == "skipped_ok"
+        after = read_sit_file(sit_path)
+        assert after.easting_m == before.easting_m
+        assert after.northing_m == before.northing_m
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        unit, site, year = _create_denabull_deployment(tmp_path, legacy_sit=True)
+        study_area = load_studyarea(str(tmp_path), unit, site, year)
+        sit_path = tmp_path / f"{unit}{site}" / "Input_Data" / "05_SITES" / f"{unit}{site}{year}.sit"
+        before = read_sit_file(sit_path)
+
+        result = migrate_sit_file(
+            sit_path,
+            study_area,
+            unit=unit,
+            site=site,
+            year=year,
+            dry_run=True,
+        )
+
+        assert result.action == "dry_run_would_migrate"
+        after = read_sit_file(sit_path)
+        assert after.easting_m == before.easting_m
+        assert after.northing_m == before.northing_m
+
+
+class TestMigrateProjectSites:
+    def test_discover_and_migrate_all(self, tmp_path):
+        unit, site, year = _create_denabull_deployment(tmp_path, legacy_sit=True)
+
+        discovered = discover_deployment_sits(tmp_path)
+        assert discovered == [(unit, site, year, discovered[0][3])]
+
+        results = migrate_project_sites(tmp_path)
+        assert len(results) == 1
+        assert results[0].action == "migrated"
+
+        get_deployment(str(tmp_path), unit, site, year, elevation=False)
+
+    def test_migrate_single_deployment(self, tmp_path):
+        unit, site, year = _create_denabull_deployment(tmp_path, legacy_sit=True)
+
+        result = migrate_deployment_sit(tmp_path, unit, site, year)
+        assert result.action == "migrated"
+
+    def test_missing_sit_returns_failed(self, tmp_path):
+        result = migrate_deployment_sit(tmp_path, "DENA", "BULL", 2019)
+        assert result.action == "failed"
+        assert "not found" in (result.message or "").lower()
+
+    def test_failed_coords_outside_study_area(self, tmp_path):
+        unit, site, year = "TEST", "0001", 2025
+        site_dir = tmp_path / f"{unit}{site}"
+        dem_path = tmp_path / "source_dem.tif"
+        write_source_dem(dem_path, bounds_4269=(-136.2, 58.4, -135.8, 58.8), elevation=1000.0)
+
+        setup_site(
+            site_dir=site_dir,
+            unit=unit,
+            site=site,
+            year=year,
+            mic_coord=(-136.0, 58.6),
+            studyarea_sw=(-136.1, 58.5),
+            studyarea_ne=(-135.9, 58.7),
+            source_dem=dem_path,
+        )
+
+        study_area = load_studyarea(str(tmp_path), unit, site, year)
+        sit_path = site_dir / "Input_Data" / "05_SITES" / f"{unit}{site}{year}.sit"
+        create_site_file(
+            site_dir=site_dir,
+            unit=unit,
+            site=site,
+            year=year,
+            easting_m=1.0,
+            northing_m=1.0,
+        )
+
+        result = migrate_sit_file(
+            sit_path,
+            study_area,
+            unit=unit,
+            site=site,
+            year=year,
+        )
+        assert result.action == "failed"
+        assert "project_setup" in (result.message or "")


### PR DESCRIPTION
## Summary
- Fix `#75` regression in `run_ground_truthing.py`: use `microphone.crs` from `get_deployment()` instead of the `coords_to_utm()` tuple
- Extract `project_setup.py` into `nps_active_space/setup/` (`site_writer.py`, `site_decoder.py`, `elevation.py`, `workflow.py`); CLI is argparse + config only
- Align `.sit` microphone coords to NMSIM project UTM zone (western study-area edge); fixes cross-zone deployments (e.g. DENABULL)
- Legacy mic-local `.sit` files: `get_deployment()` raises with a copy-paste `project_setup` command; `migrate_project_sites.py` rewrites on-disk `.sit` files without full re-setup
- Deduplicate `ActiveSpaceGenerator` site dir / `.sit` writing via shared setup helpers

## Context
PR #75 changed `coords_to_utm` to return `tuple[str, int]`. This PR fixes the missed ground-truthing caller and refactors project setup. PR #84 will need the new `coords_to_utm` signature.

## Test plan
- [x] `pytest tests/setup/` (16 passed)
- [x] `pytest` (96 passed)
- [x] Manual: ground truthing app with existing `.sit`/study area
- [x] Manual: `project_setup.py` against a configured environment
- [x] Manual: `migrate_project_sites.py --dry-run` on legacy `.sit` if available

<details><summary>Example Creation of Bull River site folder</summary>
<p>

```bash
$ python -m nps_active_space.scripts.project_setup -e DENA -u DENA -s BULL -y 2026 --mic-coord -149.62901 63.39192 --studyarea-sw -150.02907 63.21250 --studyarea-ne -149.22895 63.57134
```

```bash
python -m nps_active_space.scripts.viz DENABULL2026 -e DENA
```

<img width="942" height="749" alt="image" src="https://github.com/user-attachments/assets/984466e4-db87-4f5b-b21a-fc0e6394045e" />


</p>
</details>

<details><summary>Migration script dry run on current `T:\ResMgmt\Sound\NMSim_Partial_Extract\NMSim\01 SITES` contents </summary>
<p>

```
python -m nps_active_space.scripts.migrate_project_sites -e DENA --all --dry-run
Skipping non-canonical .sit file: T:\ResMgmt\Sound\NMSim_Partial_Extract\NMSim\01 SITES\DENANTRL\Input_Data\05_SITES\DENANTRL.sit
Skipping non-canonical .sit file: T:\ResMgmt\Sound\NMSim_Partial_Extract\NMSim\01 SITES\DENANTRL\Input_Data\05_SITES\NONSENSE.sit
Skipping non-canonical .sit file: T:\ResMgmt\Sound\NMSim_Partial_Extract\NMSim\01 SITES\DENASUSH_\Input_Data\05_SITES\DENASUSH2018.sit
Skipping non-canonical .sit file: T:\ResMgmt\Sound\NMSim_Partial_Extract\NMSim\01 SITES\DENASUSH_\Input_Data\05_SITES\DENASUSH2026.sit
Skipping non-canonical .sit file: T:\ResMgmt\Sound\NMSim_Partial_Extract\NMSim\01 SITES\GLBALSTL\Input_Data\05_SITES\GLBALSTL.sit
ok       DENA BULL 2019  already project zone (epsg:26905)
ok       DENA BULL 2026  already project zone (epsg:26905)
ok       DENA CNTW 2021  already project zone (epsg:26906)
ok       DENA NTRL 2011  already project zone (epsg:26906)
ok       DENA NTRL 2019  already project zone (epsg:26906)
ok       DENA SUSH 2026  already project zone (epsg:26906)
ok       DENA TRLA 2009  already project zone (epsg:26906)
ok       DENA TRLA 2016  already project zone (epsg:26906)
ok       DENA TRLA 2017  already project zone (epsg:26906)
ok       DENA TRLA 2018  already project zone (epsg:26906)
ok       DENA TRLA 2019  already project zone (epsg:26906)
ok       DENA TRLA 2020  already project zone (epsg:26906)
ok       DENA TRLA 2021  already project zone (epsg:26906)
ok       DENA TRLA 2022  already project zone (epsg:26906)
ok       DENA TRLA 2023  already project zone (epsg:26906)
ok       DENA TRLA 2024  already project zone (epsg:26906)
ok       DENA TRLA 2025  already project zone (epsg:26906)
ok       GLBA BEARD 2023  already project zone (epsg:26908)
ok       GLBA LSTL 2024  already project zone (epsg:26908)
ok       GLBA MCLEOD 2023  already project zone (epsg:26908)
ok       GLBA REID 2020  already project zone (epsg:26908)
ok       GLBA RENDU 2020  already project zone (epsg:26908)
ok       GLBA RENDU 2021  already project zone (epsg:26908)
ok       GLBA RENDU 2022  already project zone (epsg:26908)
ok       GLBA RENDU 2023  already project zone (epsg:26908)
ok       GLBA TARR 2024  already project zone (epsg:26908)
ok       GLBA WILL 2025  already project zone (epsg:26908)
ok       NACA 001 2026  already project zone (epsg:26918)
---
Summary: 0 migrated, 28 ok, 0 dry-run, 0 failed
```

</p>
</details> 

## Follow-ups (future PR?)

**Already deduped here:** `create_site_dir`, `write_site_file`.

**Remaining `ActiveSpaceGenerator` overlap:**
- **Elevation:** `setup.create_elevation_tif` (rasterio, feet→meters, int16) vs `_mask_dem_file` (GDAL warp, no unit conversion)
- **GridFloat:** `setup.write_gridfloat` vs `_create_dem_flt`
- **`.sit`:** `_create_site_file` still writes mic-local UTM coords; only `project_setup`/`setup_site` uses project zone today

Other: NLCD landcover setup, flexible study-area ingestion.

## Question:
**Is it intended that the active space generator `_mask_dem_file` function does not convert feet-> meters? maybe I'm missing something here**