### PR TITLE
Fix operator precedence in climb_angle

### DIFF
--- a/nps_active_space/utils/computation.py
+++ b/nps_active_space/utils/computation.py
@@ -115,7 +115,7 @@ def climb_angle(v: Iterable) -> np.ndarray:
         Corresponding climb angle value in degrees.
     """
     n = np.array([0, 0, 1])  # A unit normal vector perpendicular to the xy plane
-    degrees = np.degrees(np.arcsin(np.dot(n, v) / np.linalg.norm(n) * np.linalg.norm(v)))
+    degrees = np.degrees(np.arcsin(np.dot(n, v) / (np.linalg.norm(n) * np.linalg.norm(v))))
     return degrees
 
 

--- a/tests/utils/test_climb_angle.py
+++ b/tests/utils/test_climb_angle.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+from nps_active_space.utils.computation import climb_angle
+
+
+class TestClimbAngle:
+
+    def test_non_unit_vectors(self):
+        # 3-4-5 triangle, so the climb angle is asin(4/5)
+        assert climb_angle(np.array([3., 0., 4.])) == pytest.approx(53.130102, abs=1e-5)
+        assert climb_angle(np.array([10., 0., 10.])) == pytest.approx(45., abs=1e-5)
+        assert climb_angle(np.array([1., 1., 1.])) == pytest.approx(35.264390, abs=1e-5)
+
+    def test_unit_vectors(self):
+        assert climb_angle(np.array([0., 0., 1.])) == pytest.approx(90.)
+        assert climb_angle(np.array([1., 0., 0.])) == pytest.approx(0.)
+        assert climb_angle(np.array([0., 0., -1.])) == pytest.approx(-90.)


### PR DESCRIPTION
Noticed this reading through `computation.py`. `climb_angle` doesn't match its own docstring:

```python
np.arcsin(np.dot(n, v) / np.linalg.norm(n) * np.linalg.norm(v))
```

Python evaluates that left to right, so it works out to `(n.v / |n|) * |v|` instead of `n.v / (|n| * |v|)`. The docstring gives `A = n.b = |n||b|sin(θ)`, and the version in `legacy_code/active_space_utils.py` has the parentheses, so I think this is just a typo that slipped in during the port.

Because `n` is a unit vector the division by `|n|` is a no-op, and the code ends up computing `arcsin(v_z * |v|)`. Anything longer than unit length pushes the arcsin argument past 1, so numpy returns NaN:

- `[3, 0, 4]` returns NaN, should be 53.13 degrees
- `[1, 1, 1]` returns NaN, should be 35.26
- `[10, 0, 10]` returns NaN, should be 45

It only gives the right answer when `|v|` happens to be exactly 1.

Worth saying up front: nothing in the package calls this today, so I can't point at any actual breakage. (The `climb_angle` mentions in `active_space_generator.py` are a trajectory column that happens to share the name, not this function.) It is exported in `__all__` though, so it's reachable as public API, and the math is wrong either way.

I put the tests in their own file instead of `tests/utils/test_computation.py` since #95 is currently adding that file and I didn't want the two to collide. Happy to fold them in there once that one lands.