### PR TITLE
Add config validation as a step in `initialize` and adjust schema to reflect current state

### DIFF
--- a/nps_active_space/config/DENA_example.config
+++ b/nps_active_space/config/DENA_example.config
@@ -10,7 +10,6 @@ port =
 host =
 
 [data]
-site_metadata =
 nvspl_archive = example_data/nvspl_archive
 adsb = example_data/ADS-B/healy_repeater
 ais =

--- a/nps_active_space/config/GLBA_example.config
+++ b/nps_active_space/config/GLBA_example.config
@@ -10,7 +10,6 @@ port =
 host =
 
 [data]
-site_metadata =
 nvspl_archive = example_data/nvspl_archive
 adsb =
 ais = example_data/MXAK-AIS-GLBA

--- a/nps_active_space/config/template.config
+++ b/nps_active_space/config/template.config
@@ -15,9 +15,6 @@ port =
 host =
 
 [data]
-# Absolute path to the file containing site metadata.
-# Required for run_ground_truthing.py and generate_active_space.py
-site_metadata =
 # Absolute path to the directory where an iyore dataset of acoustic deployments are stored.
 # Required for run_ground_truthing.py and generate_active_space.py
 nvspl_archive =

--- a/nps_active_space/scripts/README.md
+++ b/nps_active_space/scripts/README.md
@@ -4,6 +4,7 @@ The `nps_active_space` [toolkit architecture](https://github.com/dbetchkal/NPS-A
 
 This directory contains the scripts along with instruction for their use via a command line interface. See [below](#use-cases) for the most common use cases, and [further below](#script-usage) for detailed documentation of each script.
 
+- [validate_config.py](#validate-config)
 - [project_setup.py](#project-setup)
 - [migrate_project_sites.py](#migrate-project-sites)
 - [run_ground_truthing.py](#run-ground-truthing)
@@ -187,6 +188,23 @@ check_study_duration_robustness.py
 
 # Script Usage
 
+### Validate Config
+
+Check an environment config for structural problems and missing paths before running a pipeline script.
+
+| command-line arg | description |
+| ---------------- | ----------- |
+| `-e`, `--environment` | **required.** Config environment to validate (e.g. `DENA_example`). |
+
+Example:
+
+```bash
+python nps_active_space/scripts/validate_config.py -e DENA_example
+```
+
+Run from the repo root when the config uses relative paths such as `example_data/...`.
+
+----
 
 ### Project Setup
 

--- a/nps_active_space/scripts/validate_config.py
+++ b/nps_active_space/scripts/validate_config.py
@@ -1,0 +1,26 @@
+"""Validate an environment config file."""
+
+import argparse
+import sys
+
+import nps_active_space.utils.config as cfg
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Validate a NPS-ActiveSpace environment config file.",
+    )
+    parser.add_argument(
+        "-e",
+        "--environment",
+        required=True,
+        help="Configuration environment to validate (e.g. DENA_example).",
+    )
+    args = parser.parse_args()
+
+    try:
+        cfg.initialize(args.environment, validate_config=True)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Configuration {args.environment!r} is valid.")

--- a/nps_active_space/utils/config.py
+++ b/nps_active_space/utils/config.py
@@ -21,7 +21,7 @@ _config = None
 # so that validate() can check whether those paths exist on disk.
 EXPECTED_SCHEMA = {
     'database:overflights': ['name', 'username', 'password', 'port', 'host'],
-    'data': ['site_metadata', 'nvspl_archive', 'adsb', 'ais', 'dem', 'mennitt'],
+    'data': ['site_metadata', 'nvspl_archive', 'adsb', 'ais', 'dem', 'dem_elevation_units', 'mennitt'],
     'project': ['dir', 'nmsim', 'faa_releasable_db', 'faa_type_corrections'],
 }
 
@@ -38,7 +38,7 @@ _REQUIRED_VALUES = {
 }
 
 
-def initialize(environment: str):
+def initialize(environment: str, *, validate_config: bool = True):
     """
     Initialize a connection to a configuration file.
 
@@ -46,6 +46,13 @@ def initialize(environment: str):
     ----------
     environment : str
         The name of the environment of the configuration file to read.
+    validate_config : bool, default True
+        When True, run :func:`validate` after loading and raise if errors are found.
+
+    Raises
+    ------
+    ValueError
+        If ``validate_config`` is True and validation reports one or more errors.
 
     Example
     -------
@@ -58,6 +65,14 @@ def initialize(environment: str):
     config_file = os.path.join(ACTIVE_SPACE_DIR, "config", f"{environment}.config")
     _config = ConfigParser()
     _config.read(config_file)
+
+    if validate_config:
+        errors = validate(verbose=True)
+        if errors:
+            raise ValueError(
+                f"Configuration validation failed with {len(errors)} error(s): "
+                f"{errors[0]}"
+            )
 
 
 def read(section: str, option: Optional[str] = None) -> Union[Dict, Any]:
@@ -182,6 +197,25 @@ def _check_section_keys(
     return errors
 
 
+def _check_dem_elevation_units(config: ConfigParser) -> List[str]:
+    """Validate non-empty ``dem_elevation_units`` in ``[data]``."""
+    errors: List[str] = []
+    if not config.has_section("data"):
+        return errors
+    if not config.has_option("data", "dem_elevation_units"):
+        return errors
+    raw = config.get("data", "dem_elevation_units").strip()
+    if not raw:
+        return errors
+    try:
+        SourceElevationUnits.parse_config_value(raw)
+    except ValueError:
+        errors.append(
+            f"[data] dem_elevation_units must be 'feet' or 'meters', got '{raw}'"
+        )
+    return errors
+
+
 def validate(verbose: bool = True) -> List[str]:
     """
     Validate the currently loaded configuration.
@@ -193,6 +227,7 @@ def validate(verbose: bool = True) -> List[str]:
     4. Required values (like ``[project] dir``) are non-empty.
     5. Non-empty path values point to an existing file or directory.
     6. Unknown sections or keys are flagged (catches typos).
+    7. Non-empty ``dem_elevation_units`` values are ``feet`` or ``meters``.
 
     Parameters
     ----------
@@ -238,6 +273,8 @@ def validate(verbose: bool = True) -> List[str]:
             _PATH_KEYS.get(section, set()),
             _REQUIRED_VALUES.get(section, set()),
         ))
+
+    errors.extend(_check_dem_elevation_units(_config))
 
     if verbose:
         for msg in errors:

--- a/nps_active_space/utils/config.py
+++ b/nps_active_space/utils/config.py
@@ -49,6 +49,12 @@ def initialize(environment: str, *, validate_config: bool = True):
     validate_config : bool, default True
         When True, run :func:`validate` after loading and raise if errors are found.
 
+    Notes
+    -----
+    Relative path values in the config are checked against the current working
+    directory. Run scripts from the repo root when using relative paths such as
+    ``example_data/...`` (see the bundled ``*_example.config`` files).
+
     Raises
     ------
     ValueError
@@ -228,6 +234,11 @@ def validate(verbose: bool = True) -> List[str]:
     5. Non-empty path values point to an existing file or directory.
     6. Unknown sections or keys are flagged (catches typos).
     7. Non-empty ``dem_elevation_units`` values are ``feet`` or ``meters``.
+
+    Notes
+    -----
+    Non-absolute path values are resolved with :func:`os.path.exists` relative
+    to the current working directory, not the config file location.
 
     Parameters
     ----------

--- a/nps_active_space/utils/config.py
+++ b/nps_active_space/utils/config.py
@@ -21,13 +21,13 @@ _config = None
 # so that validate() can check whether those paths exist on disk.
 EXPECTED_SCHEMA = {
     'database:overflights': ['name', 'username', 'password', 'port', 'host'],
-    'data': ['site_metadata', 'nvspl_archive', 'adsb', 'ais', 'dem', 'dem_elevation_units', 'mennitt'],
+    'data': ['nvspl_archive', 'adsb', 'ais', 'dem', 'dem_elevation_units', 'mennitt'],
     'project': ['dir', 'nmsim', 'faa_releasable_db', 'faa_type_corrections'],
 }
 
 # Keys whose non-empty values should point to an existing file or directory.
 _PATH_KEYS = {
-    'data': {'site_metadata', 'nvspl_archive', 'adsb', 'ais', 'dem', 'mennitt'},
+    'data': {'nvspl_archive', 'adsb', 'ais', 'dem', 'mennitt'},
     'project': {'dir', 'nmsim', 'faa_releasable_db', 'faa_type_corrections'},
 }
 

--- a/tests/fixtures/full_example_data.config
+++ b/tests/fixtures/full_example_data.config
@@ -1,0 +1,21 @@
+[database:overflights]
+name = mydb
+username = user
+password = secret
+port = 5432
+host = localhost
+
+[data]
+site_metadata = example_data/site_projects/DENATRLA/Input_Data/05_SITES/DENATRLA2025.sit
+nvspl_archive = example_data/nvspl_archive
+adsb = example_data/ADS-B/healy_repeater
+ais = example_data/MXAK-AIS-GLBA
+dem = example_data/site_projects/DENATRLA/Input_Data/01_ELEVATION/elevation_m_nad83_utm6.tif
+dem_elevation_units = feet
+mennitt = example_data/site_projects/DENATRLA/Input_Data/01_ELEVATION/elevation_m_nad83_utm6.tif
+
+[project]
+dir = example_data/site_projects
+nmsim =
+faa_releasable_db = example_data/faa/MASTER_DENATRLA_20250623_sample.txt
+faa_type_corrections = example_data/faa/FAA_AircraftCorrections.json

--- a/tests/fixtures/full_example_data.config
+++ b/tests/fixtures/full_example_data.config
@@ -1,4 +1,4 @@
-# All schema keys populated for validation testing.
+# All schema keys present; path values populated where bundled data or stubs exist.
 # Uses example_data/ where bundled data exists; tests/fixtures/stubs/ elsewhere.
 # Run validation from repo root (see TestExampleConfigs).
 
@@ -10,7 +10,6 @@ port = 5432
 host = localhost
 
 [data]
-site_metadata = tests/fixtures/stubs/site_metadata.csv
 nvspl_archive = example_data/nvspl_archive
 adsb = example_data/ADS-B/healy_repeater
 ais = example_data/MXAK-AIS-GLBA

--- a/tests/fixtures/full_example_data.config
+++ b/tests/fixtures/full_example_data.config
@@ -1,3 +1,7 @@
+# All schema keys populated for validation testing.
+# Uses example_data/ where bundled data exists; tests/fixtures/stubs/ elsewhere.
+# Run validation from repo root (see TestExampleConfigs).
+
 [database:overflights]
 name = mydb
 username = user
@@ -6,16 +10,16 @@ port = 5432
 host = localhost
 
 [data]
-site_metadata = example_data/site_projects/DENATRLA/Input_Data/05_SITES/DENATRLA2025.sit
+site_metadata = tests/fixtures/stubs/site_metadata.csv
 nvspl_archive = example_data/nvspl_archive
 adsb = example_data/ADS-B/healy_repeater
 ais = example_data/MXAK-AIS-GLBA
 dem = example_data/site_projects/DENATRLA/Input_Data/01_ELEVATION/elevation_m_nad83_utm6.tif
 dem_elevation_units = feet
-mennitt = example_data/site_projects/DENATRLA/Input_Data/01_ELEVATION/elevation_m_nad83_utm6.tif
+mennitt = tests/fixtures/stubs/mennitt.tif
 
 [project]
 dir = example_data/site_projects
-nmsim =
+nmsim = tests/fixtures/stubs/nmsim.exe
 faa_releasable_db = example_data/faa/MASTER_DENATRLA_20250623_sample.txt
 faa_type_corrections = example_data/faa/FAA_AircraftCorrections.json

--- a/tests/fixtures/stubs/mennitt.tif
+++ b/tests/fixtures/stubs/mennitt.tif
@@ -1,0 +1,1 @@
+placeholder

--- a/tests/fixtures/stubs/nmsim.exe
+++ b/tests/fixtures/stubs/nmsim.exe
@@ -1,0 +1,1 @@
+placeholder

--- a/tests/fixtures/stubs/site_metadata.csv
+++ b/tests/fixtures/stubs/site_metadata.csv
@@ -1,2 +1,0 @@
-unit,site,year
-DENA,TRLA,2025

--- a/tests/fixtures/stubs/site_metadata.csv
+++ b/tests/fixtures/stubs/site_metadata.csv
@@ -1,0 +1,2 @@
+unit,site,year
+DENA,TRLA,2025

--- a/tests/utils/test_config_validation.py
+++ b/tests/utils/test_config_validation.py
@@ -323,6 +323,35 @@ def repo_root():
     return Path(__file__).resolve().parents[2]
 
 
+class TestTemplateSchemaSync:
+    def test_template_sections_match_expected_schema(self):
+        from configparser import ConfigParser
+
+        from nps_active_space import ACTIVE_SPACE_DIR
+
+        parser = ConfigParser()
+        template_path = Path(ACTIVE_SPACE_DIR) / "config" / "template.config"
+        parser.read(template_path)
+        assert set(parser.sections()) == set(cfg.EXPECTED_SCHEMA.keys())
+
+    def test_template_keys_match_expected_schema(self):
+        from configparser import ConfigParser
+
+        from nps_active_space import ACTIVE_SPACE_DIR
+
+        parser = ConfigParser()
+        template_path = Path(ACTIVE_SPACE_DIR) / "config" / "template.config"
+        parser.read(template_path)
+        for section, expected_keys in cfg.EXPECTED_SCHEMA.items():
+            assert set(parser[section].keys()) == set(expected_keys)
+
+    def test_path_and_required_keys_are_in_schema(self):
+        for section, path_keys in cfg._PATH_KEYS.items():
+            assert path_keys <= set(cfg.EXPECTED_SCHEMA[section])
+        for section, required_keys in cfg._REQUIRED_VALUES.items():
+            assert required_keys <= set(cfg.EXPECTED_SCHEMA[section])
+
+
 class TestExampleConfigs:
     @pytest.mark.parametrize("environment", ["DENA_example", "GLBA_example"])
     def test_shipped_example_configs_validate(

--- a/tests/utils/test_config_validation.py
+++ b/tests/utils/test_config_validation.py
@@ -1,6 +1,7 @@
 """Tests for nps_active_space.utils.config.validate()."""
 
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -34,6 +35,7 @@ nvspl_archive =
 adsb =
 ais =
 dem =
+dem_elevation_units = feet
 mennitt =
 
 [project]
@@ -96,6 +98,7 @@ class TestValidateMissingSections:
         adsb =
         ais =
         dem =
+        dem_elevation_units = feet
         mennitt =
         """)
         errors = cfg.validate(verbose=False)
@@ -142,6 +145,7 @@ class TestValidateMissingKeys:
         adsb =
         ais =
         dem =
+        dem_elevation_units = feet
         mennitt =
 
         [project]
@@ -245,3 +249,97 @@ class TestValidateVerboseOutput:
         cfg.validate(verbose=False)
         captured = capsys.readouterr()
         assert captured.out == ""
+
+
+class TestValidateDemElevationUnits:
+    def test_invalid_dem_elevation_units(self, tmp_path):
+        project_dir = tmp_path / "projects"
+        project_dir.mkdir()
+        text = VALID_CONFIG.format(project_dir=project_dir).replace(
+            "dem_elevation_units = feet",
+            "dem_elevation_units = yards",
+        )
+        _write_config(tmp_path, text)
+        errors = cfg.validate(verbose=False)
+        assert any(
+            "[data] dem_elevation_units must be 'feet' or 'meters', got 'yards'"
+            in e
+            for e in errors
+        )
+        assert len(errors) == 1
+
+    def test_blank_dem_elevation_units_is_fine(self, tmp_path):
+        project_dir = tmp_path / "projects"
+        project_dir.mkdir()
+        text = VALID_CONFIG.format(project_dir=project_dir).replace(
+            "dem_elevation_units = feet",
+            "dem_elevation_units =",
+        )
+        _write_config(tmp_path, text)
+        errors = cfg.validate(verbose=False)
+        assert errors == []
+
+
+class TestInitializeValidation:
+    def _write_env_config(self, tmp_path, name: str, body: str) -> None:
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / f"{name}.config").write_text(textwrap.dedent(body))
+
+    def test_initialize_raises_on_invalid_config(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects"
+        project_dir.mkdir()
+        self._write_env_config(
+            tmp_path,
+            "invalid_units",
+            VALID_CONFIG.format(project_dir=project_dir).replace(
+                "dem_elevation_units = feet",
+                "dem_elevation_units = bad",
+            ),
+        )
+        monkeypatch.setattr(cfg, "ACTIVE_SPACE_DIR", str(tmp_path))
+        with pytest.raises(ValueError, match="Configuration validation failed"):
+            cfg.initialize("invalid_units", validate_config=True)
+
+    def test_initialize_skips_validation_when_disabled(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "projects"
+        project_dir.mkdir()
+        self._write_env_config(
+            tmp_path,
+            "invalid_units",
+            VALID_CONFIG.format(project_dir=project_dir).replace(
+                "dem_elevation_units = feet",
+                "dem_elevation_units = bad",
+            ),
+        )
+        monkeypatch.setattr(cfg, "ACTIVE_SPACE_DIR", str(tmp_path))
+        cfg.initialize("invalid_units", validate_config=False)
+        errors = cfg.validate(verbose=False)
+        assert len(errors) >= 1
+
+
+@pytest.fixture
+def repo_root():
+    return Path(__file__).resolve().parents[2]
+
+
+class TestExampleConfigs:
+    @pytest.mark.parametrize("environment", ["DENA_example", "GLBA_example"])
+    def test_shipped_example_configs_validate(
+        self, environment, repo_root, monkeypatch
+    ):
+        monkeypatch.chdir(repo_root)
+        cfg.initialize(environment, validate_config=False)
+        errors = cfg.validate(verbose=False)
+        assert errors == []
+
+    def test_full_example_data_fixture_validates(self, repo_root, monkeypatch):
+        from configparser import ConfigParser
+
+        monkeypatch.chdir(repo_root)
+        fixture_path = repo_root / "tests" / "fixtures" / "full_example_data.config"
+        parser = ConfigParser()
+        parser.read(str(fixture_path))
+        cfg._config = parser
+        errors = cfg.validate(verbose=False)
+        assert errors == []

--- a/tests/utils/test_config_validation.py
+++ b/tests/utils/test_config_validation.py
@@ -30,7 +30,6 @@ port = 5432
 host = localhost
 
 [data]
-site_metadata =
 nvspl_archive =
 adsb =
 ais =
@@ -93,7 +92,6 @@ class TestValidateMissingSections:
         host =
 
         [data]
-        site_metadata =
         nvspl_archive =
         adsb =
         ais =
@@ -140,7 +138,6 @@ class TestValidateMissingKeys:
         host =
 
         [data]
-        site_metadata =
         nvspl_archive =
         adsb =
         ais =


### PR DESCRIPTION
## Summary
- Add `dem_elevation_units` to the config validation schema and validate non-empty values as `feet` or `meters`.
- Remove `site_metadata` from config as it's not read anywhere in the non-legacy code
- Run `validate()` from `initialize()` by default (`validate_config=True`), raising `ValueError` on failure.
- Add `validate_config.py` script (`python nps_active_space/scripts/validate_config.py -e <config_name>`)

Follow-up to #83.

## Test plan
- [x] `pytest tests/utils/test_config_validation.py` (22 passed)
- [x] integration tests for `DENA_example`, `GLBA_example`, and a more complete test config.
- [x] Confirm `validate_config` script functions