### PR TITLE
Show track altitude on ground truthing hover

### DIFF
--- a/nps_active_space/ground_truthing/annotation_frames.py
+++ b/nps_active_space/ground_truthing/annotation_frames.py
@@ -183,10 +183,11 @@ class _InstructionsFrame(_AppFrame):
         instructions = tk.Label(
             content,
             text=(
-                'Mark audible periods with the range sliders under the spectrogram.\n'
-                'Use "Add Sound Event" to annotate multiple audible segments on one track.\n'
-                'Remove all audible extents and click Submit to mark a fully inaudible track.\n'
-                'Click Ignore to exclude a track from analysis when the data should not be used.'
+                'Annotate audible extent with the range sliders under the spectrogram.\n'
+                'Use "Add Sound Event" to annotate distinct extents on one track.\n'
+                'If no periods are audible, click "Remove" to remove all extents.\n'
+                'When all extents have been annotated, click "Submit" to move to the next track.\n'
+                'Click "Ignore" to dismiss a track from analysis for any reason.'
             ),
             font=('Avenir', 12),
             bg='ivory2',

--- a/nps_active_space/ground_truthing/annotation_frames.py
+++ b/nps_active_space/ground_truthing/annotation_frames.py
@@ -7,6 +7,7 @@ from shapely.geometry import Point
 from nps_active_space.ground_truthing.frame_base import _AppFrame
 from nps_active_space.ground_truthing.segments import AudibleRange
 from nps_active_space.ground_truthing import annotation_plot
+from nps_active_space.ground_truthing.annotation_plot import snap_threshold_days
 from nps_active_space.ground_truthing import dem
 from nps_active_space.ground_truthing import segments
 from nps_active_space.ground_truthing import track_context
@@ -471,7 +472,10 @@ class _GroundTruthingFrame(_AppFrame):
         self.spectro = spectro
         self.audible_ranges = audible_ranges
         self.spline = spline
-        self.typical_t_diff = spline["time_audible"].diff().median()
+        typical_t_diff = spline["time_audible"].diff().median()
+        self.typical_t_diff = typical_t_diff
+        self.spline_time_num = date2num(spline["time_audible"].to_numpy())
+        self.snap_threshold_days = snap_threshold_days(typical_t_diff)
         self.closest_point = closest_point
         self.closest_time = closest_time
         self.x_lims = x_lims

--- a/nps_active_space/ground_truthing/annotation_frames.py
+++ b/nps_active_space/ground_truthing/annotation_frames.py
@@ -472,10 +472,10 @@ class _GroundTruthingFrame(_AppFrame):
         self.spectro = spectro
         self.audible_ranges = audible_ranges
         self.spline = spline
-        typical_t_diff = spline["time_audible"].diff().median()
-        self.typical_t_diff = typical_t_diff
         self.spline_time_num = date2num(spline["time_audible"].to_numpy())
-        self.snap_threshold_days = snap_threshold_days(typical_t_diff)
+        self.snap_threshold_days = snap_threshold_days(
+            spline["time_audible"].diff().median()
+        )
         self.closest_point = closest_point
         self.closest_time = closest_time
         self.x_lims = x_lims

--- a/nps_active_space/ground_truthing/annotation_frames.py
+++ b/nps_active_space/ground_truthing/annotation_frames.py
@@ -180,9 +180,15 @@ class _InstructionsFrame(_AppFrame):
         )
         instructions = tk.Label(
             self,
-            text='Use the range slider to adjust what section of each track is audible, inaudible, or unknown.',
+            text=(
+                'Mark audible periods with the range sliders under the spectrogram.\n'
+                'Use "Add Sound Event" to annotate multiple audible segments on one track.\n'
+                'Remove all audible extents and click Submit to mark a fully inaudible track.\n'
+                'Click Ignore to exclude a track from analysis when the data should not be used.'
+            ),
             font=('Avenir', 12),
-            bg='ivory2'
+            bg='ivory2',
+            justify='center',
         )
         save_reminder = tk.Label(
             self,
@@ -291,7 +297,7 @@ class _GroundTruthingFrame(_AppFrame):
         )
         self.unknown_button = tk.Button(
             self,
-            text='Unknown >>',
+            text='Ignore >>',
             bg='yellow',
             fg='black',
             width=10,

--- a/nps_active_space/ground_truthing/annotation_frames.py
+++ b/nps_active_space/ground_truthing/annotation_frames.py
@@ -295,7 +295,7 @@ class _GroundTruthingFrame(_AppFrame):
             width=10,
             font=('Avenir', 12, 'bold')
         )
-        self.unknown_button = tk.Button(
+        self.ignore_button = tk.Button(
             self,
             text='Ignore >>',
             bg='yellow',
@@ -377,7 +377,7 @@ class _GroundTruthingFrame(_AppFrame):
         self.track_label.grid(row=0, column=1, pady=10)
         self.time_label.grid(row=1, column=1, pady=10)
         self.submit_button.grid(row=2, column=1, sticky='n')
-        self.unknown_button.grid(row=2, column=1, sticky='s')
+        self.ignore_button.grid(row=2, column=1, sticky='s')
         
         self.nav_buttons.grid(row=3, column=1)
         self.back_button.pack(side=tk.LEFT, padx=10)
@@ -585,7 +585,7 @@ class _GroundTruthingFrame(_AppFrame):
         """
         # Deactivate the decision buttons.
         self.submit_button.config(state=tk.DISABLED)
-        self.unknown_button.config(state=tk.DISABLED)
+        self.ignore_button.config(state=tk.DISABLED)
 
         gdf = segments.build_annotation_segments(
             track_id, points, audible_ranges=audible_ranges, valid=valid, note=note

--- a/nps_active_space/ground_truthing/annotation_frames.py
+++ b/nps_active_space/ground_truthing/annotation_frames.py
@@ -184,19 +184,19 @@ class _InstructionsFrame(_AppFrame):
             content,
             text=(
                 'Annotate audible extent with the range sliders under the spectrogram.\n'
-                'Use "Add Sound Event" to annotate distinct extents on one track.\n'
+                'Use "Add Sound Event" to annotate another extent on the same track.\n'
                 'If no periods are audible, click "Remove" to remove all extents.\n'
-                'When all extents have been annotated, click "Submit" to move to the next track.\n'
+                'When finished annotating a track, click "Submit" to move to the next track.\n'
                 'Click "Ignore" to dismiss a track from analysis for any reason.'
             ),
-            font=('Avenir', 12),
+            font=('Avenir', 14),
             bg='ivory2',
             justify='center',
         )
         save_reminder = tk.Label(
             content,
             text='As always, make sure to save intermittently!',
-            font=('Avenir', 12),
+            font=('Avenir', 14),
             bg='ivory2'
         )
         start_button = tk.Button(

--- a/nps_active_space/ground_truthing/annotation_frames.py
+++ b/nps_active_space/ground_truthing/annotation_frames.py
@@ -171,15 +171,17 @@ class _InstructionsFrame(_AppFrame):
     def __init__(self, master: tk.Tk) -> None:
         super().__init__(master)
 
+        content = tk.Frame(self, bg='ivory2')
+
         # Define widgets.
         frame_label = tk.Label(
-            self,
+            content,
             text='Instructions:',
             font=('Avenir', 14, 'bold'),
             bg='ivory2'
         )
         instructions = tk.Label(
-            self,
+            content,
             text=(
                 'Mark audible periods with the range sliders under the spectrogram.\n'
                 'Use "Add Sound Event" to annotate multiple audible segments on one track.\n'
@@ -191,7 +193,7 @@ class _InstructionsFrame(_AppFrame):
             justify='center',
         )
         save_reminder = tk.Label(
-            self,
+            content,
             text='As always, make sure to save intermittently!',
             font=('Avenir', 12),
             bg='ivory2'
@@ -213,10 +215,12 @@ class _InstructionsFrame(_AppFrame):
             command=lambda: self.master.switch_frame(_AnnotationLoadFrame)
         )
 
+        frame_label.pack(pady=(0, 8))
+        instructions.pack(pady=(0, 16))
+        save_reminder.pack()
+
         # Place widgets.
-        frame_label.place(relx=0.5, rely=0.35, anchor='center')
-        instructions.place(relx=0.5, rely=0.45, anchor='center')
-        save_reminder.place(relx=0.5, rely=0.5, anchor='center')
+        content.place(relx=0.5, rely=0.45, anchor='center')
         start_button.place(relx=0.9, rely=0.9, anchor='center')
         back_button.place(relx=0.1, rely=0.9, anchor='center')
 

--- a/nps_active_space/ground_truthing/annotation_plot.py
+++ b/nps_active_space/ground_truthing/annotation_plot.py
@@ -73,6 +73,28 @@ def _track_altitudes_m(points: Any) -> np.ndarray:
     return altitudes[np.isfinite(altitudes)]
 
 
+def snap_threshold_days(typical_t_diff: Any) -> float:
+    """Convert spline sample spacing to matplotlib date units for hover snapping."""
+    if typical_t_diff is None:
+        return 1.0 / 86400.0
+    try:
+        if typical_t_diff != typical_t_diff:
+            return 1.0 / 86400.0
+    except TypeError:
+        return 1.0 / 86400.0
+    return typical_t_diff.total_seconds() / 86400.0
+
+
+def closest_spline_at_cursor(
+    spline_time_num: np.ndarray,
+    cursor_x: float,
+) -> tuple[int, float]:
+    """Return nearest spline index and |Δt| in matplotlib date numbers."""
+    deltas = np.abs(spline_time_num - cursor_x)
+    closest_idx = int(np.argmin(deltas))
+    return closest_idx, float(deltas[closest_idx])
+
+
 def _track_altitude_summary(points: Any, closest_point_geometry: Any) -> str:
     """Format static track altitude stats for the side panel."""
     altitudes = _track_altitudes_m(points)
@@ -129,6 +151,8 @@ def build_plot(frame: "_GroundTruthingFrame") -> None:
     frame.fig = fig
     frame.canvas = canvas
     frame.bg = None
+    frame._plot_updating = False
+    frame._cursor_status_text = None
     frame.slider_axes = slider_axes
     frame.spectro_ax = spectro_ax
     frame.map_ax = map_ax
@@ -315,22 +339,26 @@ def on_draw(frame: "_GroundTruthingFrame", event: Any = None) -> None:
     update_plot(frame)
 
 def update_plot(frame: "_GroundTruthingFrame") -> None:
-    if frame.bg is None:
+    if frame.bg is None or frame._plot_updating:
         return
-    frame.canvas.restore_region(frame.bg)
+    frame._plot_updating = True
+    try:
+        frame.canvas.restore_region(frame.bg)
 
-    # mouse hover track point
-    frame.map_ax.draw_artist(frame.map_mousehover_point)
+        # mouse hover track point
+        frame.map_ax.draw_artist(frame.map_mousehover_point)
 
-    # audible range UIs
-    for ui in frame.audible_range_uis:
-        frame.map_ax.draw_artist(ui.highlight)
-        frame.spectro_ax.draw_artist(ui.lower_limit_line)
-        frame.spectro_ax.draw_artist(ui.upper_limit_line)
-        ui.slider.draw()
-    
-    frame.canvas.blit(frame.fig.bbox)
-    frame.canvas.flush_events()
+        # audible range UIs
+        for ui in frame.audible_range_uis:
+            frame.map_ax.draw_artist(ui.highlight)
+            frame.spectro_ax.draw_artist(ui.lower_limit_line)
+            frame.spectro_ax.draw_artist(ui.upper_limit_line)
+            ui.slider.draw()
+
+        frame.canvas.blit(frame.fig.bbox)
+        frame.canvas.flush_events()
+    finally:
+        frame._plot_updating = False
 
 def on_mouse_down(frame: "_GroundTruthingFrame", event: Any) -> None:
     if event.button == 1 and event.inaxes in frame.slider_axes:
@@ -338,25 +366,32 @@ def on_mouse_down(frame: "_GroundTruthingFrame", event: Any) -> None:
 
 def on_mouse_move(frame: "_GroundTruthingFrame", event: Any) -> None:
     if event.inaxes == frame.spectro_ax or event.inaxes in frame.slider_axes:
-        dt = num2date(event.xdata).replace(tzinfo=None)
+        if event.xdata is None:
+            return
 
-        # get closest spline point to the mouse position
-        closest_idx = (frame.spline["time_audible"] - dt).abs().idxmin()
-        closest_pt = frame.spline.loc[closest_idx]
+        cursor_time = num2date(event.xdata).replace(tzinfo=None)
+        closest_idx, time_diff_days = closest_spline_at_cursor(
+            frame.spline_time_num,
+            event.xdata,
+        )
+        closest_pt = frame.spline.iloc[closest_idx]
+        within_snap = time_diff_days <= frame.snap_threshold_days
 
-        frame.time_label.config(text=_cursor_status_text(
-            dt,
-            _point_altitude_m(closest_pt.geometry),
-        ))
+        altitude_m = (
+            _point_altitude_m(closest_pt.geometry)
+            if within_snap else None
+        )
+        status_text = _cursor_status_text(cursor_time, altitude_m)
+        if status_text != frame._cursor_status_text:
+            frame._cursor_status_text = status_text
+            frame.time_label.config(text=status_text)
 
-        # if the mouse is close enough to a point, display the marker on the map
-        if abs(closest_pt["time_audible"] - dt) > frame.typical_t_diff:
-            frame.map_mousehover_point.set_visible(False)
-        else:
-            
+        if within_snap:
             frame.map_mousehover_point.set_data(
                 [closest_pt.geometry.x], [closest_pt.geometry.y])
             frame.map_mousehover_point.set_visible(True)
+        else:
+            frame.map_mousehover_point.set_visible(False)
 
         update_plot(frame)
         

--- a/nps_active_space/ground_truthing/annotation_plot.py
+++ b/nps_active_space/ground_truthing/annotation_plot.py
@@ -107,7 +107,7 @@ def _track_altitude_summary(points: Any, closest_point_geometry: Any) -> str:
     ]
     closest_alt = _point_altitude_m(closest_point_geometry)
     if closest_alt is not None:
-        lines.append(f"Closest approach: {closest_alt:.0f} m MSL")
+        lines.append(f"Closest point altitude: {closest_alt:.0f} m MSL")
     return "\n".join(lines) + "\n"
 
 
@@ -320,7 +320,7 @@ def build_plot(frame: "_GroundTruthingFrame") -> None:
                                  f"\nValid: {frame.valid}")
     frame.progress_label.config(text=f"{frame.i+1}/{frame.master.tracks.track_id.nunique()}")
     frame.submit_button.config(command=lambda: frame._store_annotation(frame.track_id, frame.spline, frame.audible_ranges), state=tk.NORMAL)
-    frame.unknown_button.config(command=lambda: frame._store_annotation(frame.track_id, frame.spline, valid=False), state=tk.NORMAL)
+    frame.ignore_button.config(command=lambda: frame._store_annotation(frame.track_id, frame.spline, valid=False), state=tk.NORMAL)
     frame.time_label.config(text="")
     canvas.mpl_connect("motion_notify_event", lambda event: on_mouse_move(frame, event))
     canvas.mpl_connect("button_press_event", lambda event: on_mouse_down(frame, event))

--- a/nps_active_space/ground_truthing/annotation_plot.py
+++ b/nps_active_space/ground_truthing/annotation_plot.py
@@ -43,6 +43,11 @@ def _track_label_type_lines(
     return type_line, name_line
 
 
+def _show_track_altitude(track_source: TrackSource) -> bool:
+    """Return whether altitude readouts are meaningful for this track source."""
+    return track_source is not TrackSource.AIS
+
+
 def _cursor_status_text(cursor_time: dt.datetime, altitude_m: float | None) -> str:
     """Format cursor time and optional track altitude for the side panel."""
     text = f"Cursor Time: {cursor_time.strftime('%H:%M:%S')}"
@@ -306,10 +311,12 @@ def build_plot(frame: "_GroundTruthingFrame") -> None:
         frame.aircraft_type,
         getattr(frame, "vessel_name", None),
     )
-    altitude_line = _track_altitude_summary(
-        frame.points,
-        frame.closest_point.geometry.iat[0],
-    )
+    altitude_line = ""
+    if _show_track_altitude(frame.master.track_source):
+        altitude_line = _track_altitude_summary(
+            frame.points,
+            frame.closest_point.geometry.iat[0],
+        )
 
     frame.track_label.config(text=f"Microphone: {frame.master.mic.name}\n\n" + \
                                  f"Track Id: {frame.track_id}\n" + \
@@ -378,10 +385,9 @@ def on_mouse_move(frame: "_GroundTruthingFrame", event: Any) -> None:
         closest_pt = frame.spline.iloc[closest_idx]
         within_snap = time_diff_days <= frame.snap_threshold_days
 
-        altitude_m = (
-            _point_altitude_m(closest_pt.geometry)
-            if within_snap else None
-        )
+        altitude_m = None
+        if within_snap and _show_track_altitude(frame.master.track_source):
+            altitude_m = _point_altitude_m(closest_pt.geometry)
         status_text = _cursor_status_text(cursor_time, altitude_m)
         if status_text != frame._last_cursor_status_text:
             frame._last_cursor_status_text = status_text

--- a/nps_active_space/ground_truthing/annotation_plot.py
+++ b/nps_active_space/ground_truthing/annotation_plot.py
@@ -17,6 +17,14 @@ from nps_active_space.utils.enums import TrackSource
 if TYPE_CHECKING:
     from nps_active_space.ground_truthing.annotation_frames import _GroundTruthingFrame
 
+SECONDS_PER_DAY = 86_400.0
+DEFAULT_SNAP_THRESHOLD_SECONDS = 1.0
+
+
+def seconds_to_matplotlib_days(seconds: float) -> float:
+    """Convert elapsed seconds to matplotlib's floating-point day axis units."""
+    return seconds / SECONDS_PER_DAY
+
 
 def _track_label_type_lines(
     track_source: TrackSource,
@@ -81,13 +89,13 @@ def _track_altitudes_m(points: Any) -> np.ndarray:
 def snap_threshold_days(typical_t_diff: Any) -> float:
     """Convert spline sample spacing to matplotlib date units for hover snapping."""
     if typical_t_diff is None:
-        return 1.0 / 86400.0
+        return seconds_to_matplotlib_days(DEFAULT_SNAP_THRESHOLD_SECONDS)
     try:
         if typical_t_diff != typical_t_diff:
-            return 1.0 / 86400.0
+            return seconds_to_matplotlib_days(DEFAULT_SNAP_THRESHOLD_SECONDS)
     except TypeError:
-        return 1.0 / 86400.0
-    return typical_t_diff.total_seconds() / 86400.0
+        return seconds_to_matplotlib_days(DEFAULT_SNAP_THRESHOLD_SECONDS)
+    return seconds_to_matplotlib_days(typical_t_diff.total_seconds())
 
 
 def closest_spline_at_cursor(

--- a/nps_active_space/ground_truthing/annotation_plot.py
+++ b/nps_active_space/ground_truthing/annotation_plot.py
@@ -152,7 +152,7 @@ def build_plot(frame: "_GroundTruthingFrame") -> None:
     frame.canvas = canvas
     frame.bg = None
     frame._plot_updating = False
-    frame._cursor_status_text = None
+    frame._last_cursor_status_text = None
     frame.slider_axes = slider_axes
     frame.spectro_ax = spectro_ax
     frame.map_ax = map_ax
@@ -321,6 +321,7 @@ def build_plot(frame: "_GroundTruthingFrame") -> None:
     frame.progress_label.config(text=f"{frame.i+1}/{frame.master.tracks.track_id.nunique()}")
     frame.submit_button.config(command=lambda: frame._store_annotation(frame.track_id, frame.spline, frame.audible_ranges), state=tk.NORMAL)
     frame.unknown_button.config(command=lambda: frame._store_annotation(frame.track_id, frame.spline, valid=False), state=tk.NORMAL)
+    frame.time_label.config(text="")
     canvas.mpl_connect("motion_notify_event", lambda event: on_mouse_move(frame, event))
     canvas.mpl_connect("button_press_event", lambda event: on_mouse_down(frame, event))
     canvas.mpl_connect("draw_event", lambda event: on_draw(frame, event))
@@ -382,8 +383,8 @@ def on_mouse_move(frame: "_GroundTruthingFrame", event: Any) -> None:
             if within_snap else None
         )
         status_text = _cursor_status_text(cursor_time, altitude_m)
-        if status_text != frame._cursor_status_text:
-            frame._cursor_status_text = status_text
+        if status_text != frame._last_cursor_status_text:
+            frame._last_cursor_status_text = status_text
             frame.time_label.config(text=status_text)
 
         if within_snap:

--- a/nps_active_space/ground_truthing/annotation_plot.py
+++ b/nps_active_space/ground_truthing/annotation_plot.py
@@ -1,8 +1,10 @@
+import datetime as dt
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
+import shapely
 import tkinter as tk
 from matplotlib.dates import date2num, DateFormatter, num2date
 from matplotlib.gridspec import GridSpec
@@ -39,6 +41,24 @@ def _track_label_type_lines(
             )
             name_line = ""
     return type_line, name_line
+
+
+def _cursor_status_text(cursor_time: dt.datetime, altitude_m: float | None) -> str:
+    """Format cursor time and optional track altitude for the side panel."""
+    text = f"Cursor Time: {cursor_time.strftime('%H:%M:%S')}"
+    if altitude_m is not None and np.isfinite(altitude_m):
+        text += f"\nAltitude: {altitude_m:.0f} m MSL"
+    return text
+
+
+def _point_altitude_m(point_geometry: Any) -> float | None:
+    """Return MSL altitude from a shapely point, or None when unavailable."""
+    if not shapely.has_z(point_geometry):
+        return None
+    z = shapely.get_z(point_geometry)
+    if not np.isfinite(z):
+        return None
+    return float(z)
 
 
 def build_plot(frame: "_GroundTruthingFrame") -> None:
@@ -287,12 +307,14 @@ def on_mouse_move(frame: "_GroundTruthingFrame", event: Any) -> None:
     if event.inaxes == frame.spectro_ax or event.inaxes in frame.slider_axes:
         dt = num2date(event.xdata).replace(tzinfo=None)
 
-        # update time display
-        frame.time_label.config(text=f"Cursor Time: {dt.strftime('%H:%M:%S')}")
-
         # get closest spline point to the mouse position
         closest_idx = (frame.spline["time_audible"] - dt).abs().idxmin()
         closest_pt = frame.spline.loc[closest_idx]
+
+        frame.time_label.config(text=_cursor_status_text(
+            dt,
+            _point_altitude_m(closest_pt.geometry),
+        ))
 
         # if the mouse is close enough to a point, display the marker on the map
         if abs(closest_pt["time_audible"] - dt) > frame.typical_t_diff:

--- a/nps_active_space/ground_truthing/annotation_plot.py
+++ b/nps_active_space/ground_truthing/annotation_plot.py
@@ -61,6 +61,34 @@ def _point_altitude_m(point_geometry: Any) -> float | None:
     return float(z)
 
 
+def _track_altitudes_m(points: Any) -> np.ndarray:
+    """Return finite MSL altitudes for raw track points."""
+    if "z" in points.columns:
+        altitudes = points["z"].to_numpy(dtype=float)
+    else:
+        altitudes = np.array(
+            [_point_altitude_m(geom) for geom in points.geometry],
+            dtype=float,
+        )
+    return altitudes[np.isfinite(altitudes)]
+
+
+def _track_altitude_summary(points: Any, closest_point_geometry: Any) -> str:
+    """Format static track altitude stats for the side panel."""
+    altitudes = _track_altitudes_m(points)
+    if altitudes.size == 0:
+        return ""
+
+    lines = [
+        f"Track altitude: {altitudes.min():.0f}–{altitudes.max():.0f} m MSL "
+        f"(mean {altitudes.mean():.0f})"
+    ]
+    closest_alt = _point_altitude_m(closest_point_geometry)
+    if closest_alt is not None:
+        lines.append(f"Closest approach: {closest_alt:.0f} m MSL")
+    return "\n".join(lines) + "\n"
+
+
 def build_plot(frame: "_GroundTruthingFrame") -> None:
     """
     Build the matplotlib GridSpec plot for a track, using class state set by _load_index().
@@ -254,11 +282,16 @@ def build_plot(frame: "_GroundTruthingFrame") -> None:
         frame.aircraft_type,
         getattr(frame, "vessel_name", None),
     )
+    altitude_line = _track_altitude_summary(
+        frame.points,
+        frame.closest_point.geometry.iat[0],
+    )
 
     frame.track_label.config(text=f"Microphone: {frame.master.mic.name}\n\n" + \
                                  f"Track Id: {frame.track_id}\n" + \
                                  (f"{frame.aircraft_help_text}\n" if frame.aircraft_help_text is not None else "") + \
                                  name_line + type_line + \
+                                 altitude_line + \
                                  f"\nAnnotated: {frame.track_annotated}" + \
                                  f"\nValid: {frame.valid}")
     frame.progress_label.config(text=f"{frame.i+1}/{frame.master.tracks.track_id.nunique()}")

--- a/tests/ground_truthing/test_annotation_plot.py
+++ b/tests/ground_truthing/test_annotation_plot.py
@@ -8,11 +8,13 @@ from matplotlib.dates import date2num
 from shapely.geometry import Point
 
 from nps_active_space.ground_truthing.annotation_plot import (
+    DEFAULT_SNAP_THRESHOLD_SECONDS,
     _cursor_status_text,
     _point_altitude_m,
     _show_track_altitude,
     _track_altitude_summary,
     closest_spline_at_cursor,
+    seconds_to_matplotlib_days,
     snap_threshold_days,
 )
 from nps_active_space.utils.enums import TrackSource
@@ -76,15 +78,21 @@ class TestClosestSplineAtCursor:
         spline_time_num = date2num(
             pd.date_range("2020-01-01 12:00:00", periods=5, freq="s")
         )
-        cursor_x = spline_time_num[-1] + (120.0 / 86400.0)
+        padding_seconds = 120.0
+        cursor_x = spline_time_num[-1] + seconds_to_matplotlib_days(padding_seconds)
         closest_idx, delta_days = closest_spline_at_cursor(spline_time_num, cursor_x)
         assert closest_idx == len(spline_time_num) - 1
-        assert delta_days == pytest.approx(120.0 / 86400.0)
+        assert delta_days == pytest.approx(seconds_to_matplotlib_days(padding_seconds))
 
 
 class TestSnapThresholdDays:
     def test_defaults_to_one_second_when_spacing_unknown(self):
-        assert snap_threshold_days(pd.NaT) == pytest.approx(1.0 / 86400.0)
+        assert snap_threshold_days(pd.NaT) == pytest.approx(
+            seconds_to_matplotlib_days(DEFAULT_SNAP_THRESHOLD_SECONDS)
+        )
 
     def test_converts_median_spacing(self):
-        assert snap_threshold_days(pd.Timedelta(seconds=2)) == pytest.approx(2.0 / 86400.0)
+        spacing_seconds = 2.0
+        assert snap_threshold_days(pd.Timedelta(seconds=spacing_seconds)) == pytest.approx(
+            seconds_to_matplotlib_days(spacing_seconds)
+        )

--- a/tests/ground_truthing/test_annotation_plot.py
+++ b/tests/ground_truthing/test_annotation_plot.py
@@ -53,7 +53,7 @@ class TestTrackAltitudeSummary:
         summary = _track_altitude_summary(points, Point(0.0, 0.0, 125.0))
         assert summary == (
             "Track altitude: 100–200 m MSL (mean 150)\n"
-            "Closest approach: 125 m MSL\n"
+            "Closest point altitude: 125 m MSL\n"
         )
 
     def test_returns_empty_when_no_altitude(self):

--- a/tests/ground_truthing/test_annotation_plot.py
+++ b/tests/ground_truthing/test_annotation_plot.py
@@ -1,0 +1,33 @@
+import datetime as dt
+
+import numpy as np
+from shapely.geometry import Point
+
+from nps_active_space.ground_truthing.annotation_plot import (
+    _cursor_status_text,
+    _point_altitude_m,
+)
+
+
+class TestCursorStatusText:
+    def test_includes_altitude_when_finite(self):
+        cursor_time = dt.datetime(2020, 1, 1, 12, 34, 56)
+        assert _cursor_status_text(cursor_time, 842.4) == (
+            "Cursor Time: 12:34:56\nAltitude: 842 m MSL"
+        )
+
+    def test_omits_altitude_when_missing(self):
+        cursor_time = dt.datetime(2020, 1, 1, 12, 34, 56)
+        assert _cursor_status_text(cursor_time, None) == "Cursor Time: 12:34:56"
+
+    def test_omits_altitude_when_not_finite(self):
+        cursor_time = dt.datetime(2020, 1, 1, 12, 34, 56)
+        assert _cursor_status_text(cursor_time, np.nan) == "Cursor Time: 12:34:56"
+
+
+class TestPointAltitudeM:
+    def test_reads_z_from_3d_point(self):
+        assert _point_altitude_m(Point(1.0, 2.0, 123.4)) == 123.4
+
+    def test_returns_none_for_2d_point(self):
+        assert _point_altitude_m(Point(1.0, 2.0)) is None

--- a/tests/ground_truthing/test_annotation_plot.py
+++ b/tests/ground_truthing/test_annotation_plot.py
@@ -10,10 +10,12 @@ from shapely.geometry import Point
 from nps_active_space.ground_truthing.annotation_plot import (
     _cursor_status_text,
     _point_altitude_m,
+    _show_track_altitude,
     _track_altitude_summary,
     closest_spline_at_cursor,
     snap_threshold_days,
 )
+from nps_active_space.utils.enums import TrackSource
 from helpers import make_track_points
 
 
@@ -39,6 +41,14 @@ class TestPointAltitudeM:
 
     def test_returns_none_for_2d_point(self):
         assert _point_altitude_m(Point(1.0, 2.0)) is None
+
+
+class TestShowTrackAltitude:
+    def test_hidden_for_ais(self):
+        assert _show_track_altitude(TrackSource.AIS) is False
+
+    def test_shown_for_adsb(self):
+        assert _show_track_altitude(TrackSource.ADSB) is True
 
 
 class TestTrackAltitudeSummary:

--- a/tests/ground_truthing/test_annotation_plot.py
+++ b/tests/ground_truthing/test_annotation_plot.py
@@ -2,12 +2,17 @@ import datetime as dt
 
 import geopandas as gpd
 import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.dates import date2num
 from shapely.geometry import Point
 
 from nps_active_space.ground_truthing.annotation_plot import (
     _cursor_status_text,
     _point_altitude_m,
     _track_altitude_summary,
+    closest_spline_at_cursor,
+    snap_threshold_days,
 )
 from helpers import make_track_points
 
@@ -54,3 +59,22 @@ class TestTrackAltitudeSummary:
     def test_returns_empty_when_no_altitude(self):
         points = make_track_points(2)
         assert _track_altitude_summary(points, Point(0.0, 0.0)) == ""
+
+
+class TestClosestSplineAtCursor:
+    def test_snaps_to_track_end_when_cursor_is_in_padding(self):
+        spline_time_num = date2num(
+            pd.date_range("2020-01-01 12:00:00", periods=5, freq="s")
+        )
+        cursor_x = spline_time_num[-1] + (120.0 / 86400.0)
+        closest_idx, delta_days = closest_spline_at_cursor(spline_time_num, cursor_x)
+        assert closest_idx == len(spline_time_num) - 1
+        assert delta_days == pytest.approx(120.0 / 86400.0)
+
+
+class TestSnapThresholdDays:
+    def test_defaults_to_one_second_when_spacing_unknown(self):
+        assert snap_threshold_days(pd.NaT) == pytest.approx(1.0 / 86400.0)
+
+    def test_converts_median_spacing(self):
+        assert snap_threshold_days(pd.Timedelta(seconds=2)) == pytest.approx(2.0 / 86400.0)

--- a/tests/ground_truthing/test_annotation_plot.py
+++ b/tests/ground_truthing/test_annotation_plot.py
@@ -1,12 +1,15 @@
 import datetime as dt
 
+import geopandas as gpd
 import numpy as np
 from shapely.geometry import Point
 
 from nps_active_space.ground_truthing.annotation_plot import (
     _cursor_status_text,
     _point_altitude_m,
+    _track_altitude_summary,
 )
+from helpers import make_track_points
 
 
 class TestCursorStatusText:
@@ -31,3 +34,23 @@ class TestPointAltitudeM:
 
     def test_returns_none_for_2d_point(self):
         assert _point_altitude_m(Point(1.0, 2.0)) is None
+
+
+class TestTrackAltitudeSummary:
+    def test_summarizes_track_and_closest_altitudes(self):
+        points = make_track_points(3)
+        points["z"] = [100.0, 200.0, 150.0]
+        points.geometry = gpd.points_from_xy(
+            points.geometry.x,
+            points.geometry.y,
+            points["z"],
+        )
+        summary = _track_altitude_summary(points, Point(0.0, 0.0, 125.0))
+        assert summary == (
+            "Track altitude: 100–200 m MSL (mean 150)\n"
+            "Closest approach: 125 m MSL\n"
+        )
+
+    def test_returns_empty_when_no_altitude(self):
+        points = make_track_points(2)
+        assert _track_altitude_summary(points, Point(0.0, 0.0)) == ""


### PR DESCRIPTION
## Summary
- Show MSL altitude for the nearest spline point in the ground truthing side panel when hovering over the spectrogram or audible-range sliders
- Also show summary of altitude for track under the other track info
- Add small helpers and unit tests for cursor status text and 3D point altitude extraction
- Change startup instructions to reflect current state of application (addresses https://github.com/dbetchkal/NPS-ActiveSpace/issues/66)

Note: we chose to hide altitude info for vessels since it would just be all 0 MSL with our current available information

## Test plan
- [x] `pytest tests/ground_truthing/test_annotation_plot.py`
- [x] Manual: launch ground truthing on an ADSB tracks and confirm altitude displays correctly, then launch for AIS and confirm no altitude displays